### PR TITLE
Ios date picker set locale prop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@axsy-dev/react-native-form-generator",
-  "version": "0.9.21",
+  "version": "0.9.23",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -33,5 +33,5 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "version": "0.9.22"
+  "version": "0.9.23"
 }

--- a/src/lib/DatePickerComponent.ios.js
+++ b/src/lib/DatePickerComponent.ios.js
@@ -86,6 +86,7 @@ export class DatePickerComponent extends React.Component {
         timeZoneOffsetInMinutes={this.props.timeZoneOffsetInMinutes}
         value={this.state.date || new Date()}
         onChange={this.handleValueChange.bind(this)}
+        locale={this.props.locale}
       />
     );
 


### PR DESCRIPTION
this PR sets the `locale` prop on the `DatePickerComponent.ios.js`. Other platforms seem to already handle locales correctly.