### PR TITLE
Support picklist constants

### DIFF
--- a/src/lib/PickerComponent.android.js
+++ b/src/lib/PickerComponent.android.js
@@ -18,11 +18,18 @@ export class PickerComponent extends React.Component {
     this.state = {};
     this.pickerMeasures = {};
   }
+  
   setValue(value) {}
+
+  componentDidMount() {
+    this.handleValueChange(this.props.value);
+  }
+  
   handleLayoutChange = e => {
     let { x, y, width, height } = { ...e.nativeEvent.layout };
     this.setState(e.nativeEvent.layout);
   };
+  
   handleValueChange = value => {
     this.setState({ value });
 

--- a/src/lib/PickerComponent.android.js
+++ b/src/lib/PickerComponent.android.js
@@ -22,7 +22,9 @@ export class PickerComponent extends React.Component {
   setValue(value) {}
 
   componentDidMount() {
-    this.handleValueChange(this.props.value);
+    const { value } = this.props;
+    
+    !!value && this.handleValueChange(value);
   }
   
   handleLayoutChange = e => {

--- a/src/lib/PickerComponent.android.js
+++ b/src/lib/PickerComponent.android.js
@@ -33,7 +33,15 @@ export class PickerComponent extends React.Component {
   render() {
     // prefer state value if set
     const value = this.state.value ? this.state.value : this.props.value;
-    const selectedOption = _.find(this.props.options, o => o.value === value);
+    
+    const selectedOption = _.find(
+      this.props.options,
+      o => (
+        o.value === this.state.value ||
+        o.constant === this.state.value
+      )
+    );
+    
     return (
       <TestPathSegment name={`Field[${this.props.fieldRef}]` || "Picker"}>
         <View>

--- a/src/lib/PickerComponent.ios.js
+++ b/src/lib/PickerComponent.ios.js
@@ -69,11 +69,17 @@ export class PickerComponent extends React.Component {
     };
     this.pickerMeasures = {};
   }
+  
+  componentDidMount() {
+    this.handleValueChange(this.props.value);
+  }
+  
   setValue(value) {
     this.setState({ value: value });
     if (this.props.onChange) this.props.onChange(value);
     if (this.props.onValueChange) this.props.onValueChange(value);
   }
+  
   handleLayoutChange(e) {
     let { x, y, width, height } = { ...e.nativeEvent.layout };
 

--- a/src/lib/PickerComponent.ios.js
+++ b/src/lib/PickerComponent.ios.js
@@ -71,9 +71,11 @@ export class PickerComponent extends React.Component {
   }
   
   componentDidMount() {
-    this.handleValueChange(this.props.value);
+    const { value } = this.props;
+    
+    !!value && this.handleValueChange(value);
   }
-  
+    
   setValue(value) {
     this.setState({ value: value });
     if (this.props.onChange) this.props.onChange(value);

--- a/src/lib/PickerComponent.ios.js
+++ b/src/lib/PickerComponent.ios.js
@@ -135,10 +135,15 @@ export class PickerComponent extends React.Component {
     if (iconRight && iconRight.constructor === Array) {
       iconRight = !this.state.isPickerVisible ? iconRight[0] : iconRight[1];
     }
+    
     const selectedOption = _.find(
       this.props.options,
-      o => o.value === this.state.value
+      o => (
+        o.value === this.state.value ||
+        o.constant === this.state.value
+      )
     );
+    
     return (
       <TestPathSegment name={`Field[${this.props.fieldRef}]` || "Picker"}>
         <View>

--- a/src/lib/PickerComponent.windows.js
+++ b/src/lib/PickerComponent.windows.js
@@ -24,11 +24,17 @@ export class PickerComponent extends React.Component {
     };
     this.pickerMeasures = {};
   }
+
+  componentDidMount() {
+    this.handleValueChange(this.props.value);
+  }
+  
   setValue = value => {
     this.setState({ value: value });
     if (this.props.onChange) this.props.onChange(value);
     if (this.props.onValueChange) this.props.onValueChange(value);
   };
+  
   handleLayoutChange = e => {
     let { x, y, width, height } = { ...e.nativeEvent.layout };
 
@@ -57,10 +63,12 @@ export class PickerComponent extends React.Component {
       this.props.onFocus(event, handle);
     }
   };
+  
   _togglePicker = event => {
     this.setState({ isPickerVisible: !this.state.isPickerVisible });
     this.props.onPress && this.props.onPress(event);
   };
+  
   render() {
     let iconLeft = this.props.iconLeft,
       iconRight = this.props.iconRight;

--- a/src/lib/PickerComponent.windows.js
+++ b/src/lib/PickerComponent.windows.js
@@ -71,9 +71,13 @@ export class PickerComponent extends React.Component {
     if (iconRight && iconRight.constructor === Array) {
       iconRight = !this.state.isPickerVisible ? iconRight[0] : iconRight[1];
     }
+    
     const selectedOption = _.find(
       this.props.options,
-      o => o.value === this.state.value
+      o => (
+        o.value === this.state.value ||
+        o.constant === this.state.value
+      )
     );
 
     return (

--- a/src/lib/PickerComponent.windows.js
+++ b/src/lib/PickerComponent.windows.js
@@ -26,7 +26,9 @@ export class PickerComponent extends React.Component {
   }
 
   componentDidMount() {
-    this.handleValueChange(this.props.value);
+    const { value } = this.props;
+    
+    !!value && this.handleValueChange(value);
   }
   
   setValue = value => {


### PR DESCRIPTION
In recent versions of Flow the new pick list option field `constant` has been added:

```
{
  label: value.label,
  constant: value.constant,
  value: value.value
}
```

We need to utilize this `constant` field when checking for selected pick list option.

Additionally if the Picker component has value provided on mount - we'll trigger `onValueChange` event to make sure that Picker default value is reflected in overall data model.