### PR TITLE
Fix windows datetime issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@axsy-dev/react-native-form-generator",
-  "version": "0.9.24",
+  "version": "0.9.25",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -33,5 +33,5 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "version": "0.9.24"
+  "version": "0.9.25"
 }

--- a/src/lib/DatePickerComponent.windows.js
+++ b/src/lib/DatePickerComponent.windows.js
@@ -65,9 +65,20 @@ export class DatePickerComponent extends React.Component {
       const timezoneOffsetInHours = new Date().getTimezoneOffset() / 60;
       const selectedHoursWithOffset = selectedHours + timezoneOffsetInHours;
 
+      // Due to some weird time results with offsets returned on Windows 
+      // We need to manually setDate to make sure that it stays the same as was originally selected.
       dateToSet = new Date(this.state.date);
+      
+      const selectedDate = dateToSet.getDate();
+      const selectedMonth = dateToSet.getMonth();
+      const selectedFullYear = dateToSet.getFullYear();
+
       dateToSet.setHours(selectedHoursWithOffset);
       dateToSet.setMinutes(selectedMinutes);
+      dateToSet.setDate(selectedDate);
+      dateToSet.setMonth(selectedMonth);
+      dateToSet.setFullYear(selectedFullYear);
+      
       dateTimeFormatted = dateTimeFormat(dateToSet, mode);
     }
     else {
@@ -207,6 +218,7 @@ export class DatePickerComponent extends React.Component {
               is24Hour={false}
               minuteInterval={5}
               onChange={this.onChange}
+              timeZoneOffsetInSeconds={0} // This is necessary since DateTimePicker for some reason adds -1 hr timezone offset
             />
           ) : null}
         </View>


### PR DESCRIPTION
On Windows there's a -1 hour timezone offset added by datetimepicker https://github.com/react-native-datetimepicker/datetimepicker/blob/master/src/datetimepicker.windows.js#L47 which might lead to wrong date being selected.

To prevent that we explicitly set timezoneOffset to be 0 and making sure that correct date is set when using time picker.