### PR TITLE
Remove all picker imports ahead of rn 0.66 uplift

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@axsy-dev/react-native-form-generator",
-  "version": "0.9.25",
+  "version": "0.9.28",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@axsy-dev/react-native-form-generator",
-  "version": "0.9.28",
+  "version": "0.9.29",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -33,5 +33,5 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "version": "0.9.28"
+  "version": "0.9.29"
 }

--- a/package.json
+++ b/package.json
@@ -33,5 +33,5 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "version": "0.9.27"
+  "version": "0.9.28"
 }

--- a/src/fields/CountDownField.ios.js
+++ b/src/fields/CountDownField.ios.js
@@ -2,8 +2,7 @@
 
 import React from 'react';
 import ReactNative from 'react-native';
-let { View, StyleSheet, TextInput, Text, PickerIOS} = ReactNative;
-
+let { StyleSheet } = ReactNative;
 
 import {DatePickerComponent} from '../lib/DatePickerComponent';
 

--- a/src/fields/DatePickerField.android.js
+++ b/src/fields/DatePickerField.android.js
@@ -1,9 +1,6 @@
 'use strict';
 
 import React from 'react';
-import { View, StyleSheet, TextInput, Text, PickerIOS } from 'react-native';
-
-
 import { DatePickerComponent } from '../lib/DatePickerComponent';
 
 export class DatePickerField extends React.Component{

--- a/src/fields/DatePickerField.ios.js
+++ b/src/fields/DatePickerField.ios.js
@@ -1,8 +1,6 @@
 'use strict';
 
 import React from 'react';
-import { View, StyleSheet, TextInput, Text, PickerIOS} from 'react-native';
-
 
 import { DatePickerComponent } from '../lib/DatePickerComponent';
 

--- a/src/fields/PickerField.android.js
+++ b/src/fields/PickerField.android.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import ReactNative from 'react-native';
-let { View, StyleSheet, TextInput, Text, PickerIOS} = ReactNative;
+let { StyleSheet } = ReactNative;
 
 
 import {PickerComponent} from '../lib/PickerComponent';

--- a/src/fields/PickerField.ios.js
+++ b/src/fields/PickerField.ios.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import ReactNative from 'react-native';
-let { View, StyleSheet, TextInput, Text, PickerIOS} = ReactNative;
+let { StyleSheet } = ReactNative;
 
 
 import {PickerComponent} from '../lib/PickerComponent';

--- a/src/fields/TimePickerField.ios.js
+++ b/src/fields/TimePickerField.ios.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import ReactNative from 'react-native';
-let { View, StyleSheet, TextInput, Text, PickerIOS} = ReactNative;
+let { StyleSheet } = ReactNative;
 
 
 import {DatePickerComponent} from '../lib/DatePickerComponent';

--- a/src/lib/DatePickerComponent.ios.js
+++ b/src/lib/DatePickerComponent.ios.js
@@ -2,7 +2,7 @@
 
 import React from "react";
 import PropTypes from "prop-types";
-import { View, StyleSheet, TextInput, Text, DatePickerIOS } from "react-native";
+import { View } from "react-native";
 import { Field } from "./Field";
 
 import DateTimePicker from '@react-native-community/datetimepicker';

--- a/src/lib/DateTimeSelector.windows.js
+++ b/src/lib/DateTimeSelector.windows.js
@@ -4,7 +4,6 @@ import React, { Component } from "react";
 
 import {
   View,
-  Text,
   requireNativeComponent,
   ViewPropTypes
 } from "react-native";

--- a/src/lib/DateTimeSelector.windows.js
+++ b/src/lib/DateTimeSelector.windows.js
@@ -5,7 +5,6 @@ import React, { Component } from "react";
 import {
   View,
   Text,
-  Picker,
   requireNativeComponent,
   ViewPropTypes
 } from "react-native";

--- a/src/lib/InputComponent.js
+++ b/src/lib/InputComponent.js
@@ -5,7 +5,7 @@ import PropTypes from "prop-types";
 import ReactNative, { Platform, ViewPropTypes } from "react-native";
 import { Field } from "./Field.js";
 
-const { View, StyleSheet, Text, TextInput } = ReactNative;
+const { View, Text, TextInput } = ReactNative;
 
 import { TestPathSegment, TText, TTextInput } from "@axsy-dev/testable";
 

--- a/src/lib/PickerComponent.android.js
+++ b/src/lib/PickerComponent.android.js
@@ -1,7 +1,7 @@
 "use strict";
 
 import React from "react";
-import ReactNative, { View, StyleSheet, TouchableOpacity } from "react-native";
+import ReactNative, { View, TouchableOpacity } from "react-native";
 import { Field } from "../lib/Field";
 
 import {

--- a/src/lib/PickerComponent.ios.js
+++ b/src/lib/PickerComponent.ios.js
@@ -3,8 +3,7 @@
 import React from "react";
 import _ from "lodash";
 import PropTypes from "prop-types";
-import ReactNative from "react-native";
-let { View, StyleSheet } = ReactNative;
+import { View } from "react-native";
 import { Field } from "../lib/Field";
 
 import {

--- a/src/lib/PickerComponent.windows.js
+++ b/src/lib/PickerComponent.windows.js
@@ -3,7 +3,7 @@
 import React from "react";
 import ReactNative from "react-native";
 import PropTypes from "prop-types";
-let { View, StyleSheet, TextInput, Text, Picker } = ReactNative;
+let { StyleSheet } = ReactNative;
 import { Field } from "../lib/Field";
 
 import {

--- a/src/lib/PickerComponent.windows.js
+++ b/src/lib/PickerComponent.windows.js
@@ -3,7 +3,6 @@
 import React from "react";
 import ReactNative from "react-native";
 import PropTypes from "prop-types";
-let { StyleSheet } = ReactNative;
 import { Field } from "../lib/Field";
 
 import {

--- a/src/lib/TimePickerComponent.android.js
+++ b/src/lib/TimePickerComponent.android.js
@@ -2,12 +2,7 @@
 
 import React from "react";
 import PropTypes from "prop-types";
-import {
-  View,
-  StyleSheet,
-  TextInput,
-  Text,
-} from "react-native";
+import { View } from "react-native";
 
 import DateTimePicker from "@react-native-community/datetimepicker";
 


### PR DESCRIPTION
This change removes various unused imports, including unused Picker and PickerIOS imports. This needs to be done before the upcoming update of RN to version 0.66 as Picker and PickerIOS are no longer imported from react-native.