### PR TITLE
Adds an option for having all fields wrapped in a testable element / adds time stamp to DatePicker's value tid

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,5 +33,5 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "version": "0.9.27"
+  "version": "0.9.28"
 }

--- a/src/Form.js
+++ b/src/Form.js
@@ -77,10 +77,10 @@ export class Form extends Component {
             wrappedChildren.push(child);
         }, this);
 
-        return (
-            <View style={this.props.style}>
-                {wrappedChildren}
-            </View>
-          );
+    return (
+      <View style={this.props.style}>
+          {wrappedChildren}
+      </View>
+    );
     }
 }

--- a/src/Form.js
+++ b/src/Form.js
@@ -54,7 +54,6 @@ export class Form extends Component {
                 return;
             }
 
-            console.log(`child ${i} found`);
     
             const { isTestWrapped } = child.props;
             
@@ -74,17 +73,9 @@ export class Form extends Component {
                 })
             }
 
-            console.log(
-                {
-                    child, testableComponent
-                }
-            )
-
             wrappedChildren.push(child);
         }, this);
 
-        
-        console.log(wrappedChildren)
         return (
         <View style={this.props.style}>
             {wrappedChildren}

--- a/src/Form.js
+++ b/src/Form.js
@@ -36,7 +36,7 @@ export class Form extends Component {
     }
 
     underscoreToSpaced(str) {
-        var words = str.split('_');
+        var words = str.split('_');  
         var res=[];
 
         words.map(function(word, i) {
@@ -54,19 +54,41 @@ export class Form extends Component {
                 return;
             }
 
-            wrappedChildren.push(React.cloneElement(child, {
-                key: child.props.fieldKey ? child.props.fieldKey : child.type+i,
-                fieldRef : child.ref,
-                ref: child.ref,
+            console.log(`child ${i} found`);
+    
+            const { isTestWrapped } = child.props;
+            
+            let testableComponent = isTestWrapped ? child.props.testableComponent : child; 
+
+            testableComponent = React.cloneElement(testableComponent, {
+                key: testableComponent.props.fieldKey ? testableComponent.props.fieldKey : testableComponent.type+i,
+                fieldRef : testableComponent.ref,
+                ref: testableComponent.ref,
                 onFocus:this.handleFieldFocused.bind(this),
-                onChange:this.handleFieldChange.bind(this, child.ref)
-            }));
+                onChange:this.handleFieldChange.bind(this, testableComponent.ref)
+            })
+
+            if(isTestWrapped){
+                child = React.cloneElement(child, {
+                    children: testableComponent
+                })
+            }
+
+            console.log(
+                {
+                    child, testableComponent
+                }
+            )
+
+            wrappedChildren.push(child);
         }, this);
 
-    return (
-      <View style={this.props.style}>
-          {wrappedChildren}
-      </View>
-    );
+        
+        console.log(wrappedChildren)
+        return (
+        <View style={this.props.style}>
+            {wrappedChildren}
+        </View>
+        );
     }
 }

--- a/src/Form.js
+++ b/src/Form.js
@@ -54,7 +54,7 @@ export class Form extends Component {
                 return;
             }
 
-            const isTestable = Boolean(child?.key.startsWith("TestWrap["));
+            const isTestable = "hasTestableWrappers" in this.props && this.props.hasTestableWrappers === true;
             
             let formElement = isTestable ? child.props.children : child; 
 

--- a/src/Form.js
+++ b/src/Form.js
@@ -48,29 +48,30 @@ export class Form extends Component {
 
     render() {
         let wrappedChildren = [];
-
+        
         React.Children.map(this.props.children, (child, i) => {
             if (!child) {
                 return;
             }
 
-    
-            const { isTestWrapped } = child.props;
+            const isTestable = Boolean(child?.key.startsWith("TestWrap["));
             
-            let testableComponent = isTestWrapped ? child.props.testableComponent : child; 
+            let formElement = isTestable ? child.props.children : child; 
 
-            testableComponent = React.cloneElement(testableComponent, {
-                key: testableComponent.props.fieldKey ? testableComponent.props.fieldKey : testableComponent.type+i,
-                fieldRef : testableComponent.ref,
-                ref: testableComponent.ref,
+            formElement = React.cloneElement(formElement, {
+                key: formElement.props.fieldKey ? formElement.props.fieldKey : formElement.type+i,
+                fieldRef : formElement.ref,
+                ref: formElement.ref,
                 onFocus:this.handleFieldFocused.bind(this),
-                onChange:this.handleFieldChange.bind(this, testableComponent.ref)
-            })
-
-            if(isTestWrapped){
+                onChange:this.handleFieldChange.bind(this, formElement.ref)
+            });
+        
+            if (isTestable){
                 child = React.cloneElement(child, {
-                    children: testableComponent
+                    children: formElement
                 })
+            } else {
+                child = formElement;
             }
 
             wrappedChildren.push(child);

--- a/src/Form.js
+++ b/src/Form.js
@@ -54,7 +54,7 @@ export class Form extends Component {
                 return;
             }
 
-            const isTestable = "hasTestableWrappers" in this.props && this.props.hasTestableWrappers === true;
+            const isTestable = this.props.hasTestableWrappers === true;
             
             let formElement = isTestable ? child.props.children : child; 
 

--- a/src/Form.js
+++ b/src/Form.js
@@ -36,7 +36,7 @@ export class Form extends Component {
     }
 
     underscoreToSpaced(str) {
-        var words = str.split('_');  
+        var words = str.split('_');
         var res=[];
 
         words.map(function(word, i) {
@@ -48,7 +48,7 @@ export class Form extends Component {
 
     render() {
         let wrappedChildren = [];
-        
+
         React.Children.map(this.props.children, (child, i) => {
             if (!child) {
                 return;
@@ -78,9 +78,9 @@ export class Form extends Component {
         }, this);
 
         return (
-        <View style={this.props.style}>
-            {wrappedChildren}
-        </View>
-        );
+            <View style={this.props.style}>
+                {wrappedChildren}
+            </View>
+          );
     }
 }

--- a/src/lib/DatePickerComponent.android.js
+++ b/src/lib/DatePickerComponent.android.js
@@ -153,7 +153,7 @@ export class DatePickerComponent extends React.Component {
               {this.props.iconLeft ? this.props.iconLeft : null}
               {placeholderComponent}
               <View style={this.props.valueContainerStyle}>
-                <TText tid="Value" style={this.props.valueStyle}>
+                <TText tid={`Value[${this.state?.date?.getTime() || "unknown"}]`} style={this.props.valueStyle}>
                   {valueString}
                 </TText>
               </View>


### PR DESCRIPTION
The bigger change is adding a `hasTestableWrappers` prop to Form. If it's true, the direct child of the elements that are passed in will be the ones that are connected up to the form rather that the elements themselves. The idea being the elements can be wrapped in a TView with a test id that is set by the Form's parent.

I've also added the current timestamp value of Android variant of the DatePicker component to it's Value test id to make it easier to get in testing (rather than parsing "December 13, 2021, 17:00 PM")