### PR TITLE
Remove the testable library (and some typescript clean up)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,90 +1,92 @@
-React Native Form Generator
-================
+# React Native Form Generator
 
 Generate forms with native look and feel in a breeze
 
 [![NPM](https://nodei.co/npm/react-native-form-generator.png)](https://nodei.co/npm/react-native-form-generator/)
-
 
 ![rnformgendatetimefields](https://cloud.githubusercontent.com/assets/107390/16767512/1dfbf33c-4840-11e6-8085-1521b6d0c3ce.gif)
 
 ![react-native-form-generator](https://cloud.githubusercontent.com/assets/107390/12499709/edc1c298-c07a-11e5-916c-394de83ebe51.gif)
 
 ## Components
-* Picker
-* DatePicker
-* TimePicker
-* Input
-* Link
-* Separator
-* Switch
+
+- Picker
+- DatePicker
+- TimePicker
+- Input
+- Link
+- Separator
+- Switch
 
 ## Features
-* Android and IOS support, Yeah Baby!
-* Pleasant Defaults, totally overridable
-* Doesn't have dependencies
-* Use your own icon pack
-* Easy to use and clean, react style syntax
-* Automatic events handling
-* Supports custom fields and styles without adding any weird syntax (just create a react component)
-* Applies by default the current OS style
-* Inspired by tcomb, the good parts
-* Performances: just the field changed gets a setState
-* You don't need to create a 'Model' or a 'Struct' that contains your data, just create a form component (the React's way)
-* Validate InputFields based on keyboardType (can be overridden using validationFunction)
-* Multiple validators
-* Reset/Set Fields programmatically (setValue, setDate, setTime, focus)
-* Custom Wrapper for Picker & DatePicker Components (iOS Only)
+
+- Android and IOS support, Yeah Baby!
+- Pleasant Defaults, totally overridable
+- Doesn't have dependencies
+- Use your own icon pack
+- Easy to use and clean, react style syntax
+- Automatic events handling
+- Supports custom fields and styles without adding any weird syntax (just create a react component)
+- Applies by default the current OS style
+- Inspired by tcomb, the good parts
+- Performances: just the field changed gets a setState
+- You don't need to create a 'Model' or a 'Struct' that contains your data, just create a form component (the React's way)
+- Validate InputFields based on keyboardType (can be overridden using validationFunction)
+- Multiple validators
+- Reset/Set Fields programmatically (setValue, setDate, setTime, focus)
+- Custom Wrapper for Picker & DatePicker Components (iOS Only)
 
 [My blogpost about React Native Form Generator](https://medium.com/@michaelcereda/react-native-forms-the-right-way-315802f989d6#.p9oj79vt3)
 
 ## Installation
+
 ```
     npm install --save react-native-form-generator
 ```
+
 ## I'm actively working on this project
 
-* Pull requests are very very welcome. They make my day ;).
-* Master should be considered 'unstable' even if I do my best to keep it nice and safe.
-* Every release has its own branch.
-* Slider hasn't been created.
-* I have to document the code properly and do some housekeeping, i apologize in advance.
+- Pull requests are very very welcome. They make my day ;).
+- Master should be considered 'unstable' even if I do my best to keep it nice and safe.
+- Every release has its own branch.
+- Slider hasn't been created.
+- I have to document the code properly and do some housekeeping, i apologize in advance.
 
 ## Example
 
 Please check the folder _examples_ for an always up to date use case.
 
 the example below generates the form you see in the animation
-```javascript
 
+```javascript
 /*
 This is a view i use in a test app,
 very useful to list all the use cases
 */
 
-import React from 'react';
+import React from "react";
+
+import { AppRegistry, StyleSheet, Text, View, ScrollView } from "react-native";
 
 import {
-  AppRegistry,
-  StyleSheet,
-  Text,
-  View,ScrollView,
-} from 'react-native';
+  Form,
+  Separator,
+  InputField,
+  LinkField,
+  SwitchField,
+  PickerField,
+  DatePickerField,
+  TimePickerField
+} from "react-native-form-generator";
 
-
-import { Form,
-  Separator,InputField, LinkField,
-  SwitchField, PickerField,DatePickerField,TimePickerField
-} from 'react-native-form-generator';
-
-export class FormView extends React.Component{
-  constructor(props){
+export class FormView extends React.Component {
+  constructor(props) {
     super(props);
     this.state = {
-      formData:{}
-    }
+      formData: {}
+    };
   }
-  handleFormChange(formData){
+  handleFormChange(formData) {
     /*
     formData will contain all the values of the form,
     in this example.
@@ -98,146 +100,166 @@ export class FormView extends React.Component{
     }
     */
 
-    this.setState({formData:formData})
+    this.setState({ formData: formData });
     this.props.onFormChange && this.props.onFormChange(formData);
   }
-  handleFormFocus(e, component){
+  handleFormFocus(e, component) {
     //console.log(e, component);
   }
-  openTermsAndConditionsURL(){
-
-  }
-  render(){
-    return (<ScrollView keyboardShouldPersistTaps={true} style={{paddingLeft:10,paddingRight:10, height:200}}>
-      <Form
-        ref='registrationForm'
-        onFocus={this.handleFormFocus.bind(this)}
-        onChange={this.handleFormChange.bind(this)}
-        label="Personal Information">
-        <Separator />
-        <InputField
-          ref='first_name'
-          label='First Name'
-          placeholder='First Name'
-          helpText={((self)=>{
-
-            if(Object.keys(self.refs).length !== 0){
-              if(!self.refs.registrationForm.refs.first_name.valid){
-                return self.refs.registrationForm.refs.first_name.validationErrors.join("\n");
+  openTermsAndConditionsURL() {}
+  render() {
+    return (
+      <ScrollView
+        keyboardShouldPersistTaps={true}
+        style={{ paddingLeft: 10, paddingRight: 10, height: 200 }}
+      >
+        <Form
+          ref="registrationForm"
+          onFocus={this.handleFormFocus.bind(this)}
+          onChange={this.handleFormChange.bind(this)}
+          label="Personal Information"
+        >
+          <Separator />
+          <InputField
+            ref="first_name"
+            label="First Name"
+            placeholder="First Name"
+            helpText={(self => {
+              if (Object.keys(self.refs).length !== 0) {
+                if (!self.refs.registrationForm.refs.first_name.valid) {
+                  return self.refs.registrationForm.refs.first_name.validationErrors.join(
+                    "\n"
+                  );
+                }
               }
-
-            }
-            // if(!!(self.refs && self.refs.first_name.valid)){
-            // }
-          })(this)}
-          validationFunction={[(value)=>{
-            /*
+              // if(!!(self.refs && self.refs.first_name.valid)){
+              // }
+            })(this)}
+            validationFunction={[
+              value => {
+                /*
             you can have multiple validators in a single function or an array of functions
              */
 
-            if(value == '') return "Required";
-            //Initial state is null/undefined
-            if(!value) return true;
-            // Check if First Name Contains Numbers
-            var matches = value.match(/\d+/g);
-            if (matches != null) {
-                return "First Name can't contain numbers";
-            }
+                if (value == "") return "Required";
+                //Initial state is null/undefined
+                if (!value) return true;
+                // Check if First Name Contains Numbers
+                var matches = value.match(/\d+/g);
+                if (matches != null) {
+                  return "First Name can't contain numbers";
+                }
 
-            return true;
-          }, (value)=>{
-            ///Initial state is null/undefined
-            if(!value) return true;
-            if(value.indexOf('4')!=-1){
-              return "I can't stand number 4";
-            }
-            return true;
-          }]}
+                return true;
+              },
+              value => {
+                ///Initial state is null/undefined
+                if (!value) return true;
+                if (value.indexOf("4") != -1) {
+                  return "I can't stand number 4";
+                }
+                return true;
+              }
+            ]}
           />
-        <InputField ref='last_name' placeholder='Last Name'/>
-        <InputField
-          multiline={true}
-          ref='other_input'
-          placeholder='Other Input'
-          helpText='this is an helpful text it can be also very very long and it will wrap' />
-        <Separator />
-        <LinkField label="test test test" onPress={()=>{}}/>
-        <SwitchField label='I accept Terms & Conditions'
-          ref="has_accepted_conditions"
-          helpText='Please read carefully the terms & conditions'/>
-        <PickerField ref='gender'
-          label='Gender'
-          options={{
-            "": '',
-            male: 'Male',
-            female: 'Female'
-          }}/>
-          <DatePickerField ref='birthday'
-          minimumDate={new Date('1/1/1900')}
-          maximumDate={new Date()}
-          placeholder='Birthday'/>
-        <TimePickerField ref='alarm_time'
-      placeholder='Set Alarm'/>
-        <DatePickerField ref='meeting'
-          minimumDate={new Date('1/1/1900')}
-          maximumDate={new Date()} mode="datetime" placeholder='Meeting'/>
+          <InputField ref="last_name" placeholder="Last Name" />
+          <InputField
+            multiline={true}
+            ref="other_input"
+            placeholder="Other Input"
+            helpText="this is an helpful text it can be also very very long and it will wrap"
+          />
+          <Separator />
+          <LinkField label="test test test" onPress={() => {}} />
+          <SwitchField
+            label="I accept Terms & Conditions"
+            ref="has_accepted_conditions"
+            helpText="Please read carefully the terms & conditions"
+          />
+          <PickerField
+            ref="gender"
+            label="Gender"
+            options={{
+              "": "",
+              male: "Male",
+              female: "Female"
+            }}
+          />
+          <DatePickerField
+            ref="birthday"
+            minimumDate={new Date("1/1/1900")}
+            maximumDate={new Date()}
+            placeholder="Birthday"
+          />
+          <TimePickerField ref="alarm_time" placeholder="Set Alarm" />
+          <DatePickerField
+            ref="meeting"
+            minimumDate={new Date("1/1/1900")}
+            maximumDate={new Date()}
+            mode="datetime"
+            placeholder="Meeting"
+          />
         </Form>
         <Text>{JSON.stringify(this.state.formData)}</Text>
-
-      </ScrollView>);
-    }
+      </ScrollView>
+    );
   }
-
+}
 ```
 
 ## Form
+
 Form automatically attaches on change events so you just have to attach an handle to the onFocus attibute of Form to monitor all the changes.
 
 It's just a wrapper that allows you to attach onFocus (used to track focus events and keyboard events) and onChange (used to track changes in every field)
 
 ## Fields
+
 #### Common Rules
-* __Every__ field that has to propagate its value in the form __MUST__ have a ref attribute. (Separator and LinkField don't have a ref).
-Check the example to understand the use of the ref attribute.
-* All the components provided use _Field_ as wrapper in order to have the following props.
 
-| Prop (parameters) | Description |
-| --- | --- |
-| helpText | String shown as text under the component |
+- **Every** field that has to propagate its value in the form **MUST** have a ref attribute. (Separator and LinkField don't have a ref).
+  Check the example to understand the use of the ref attribute.
+- All the components provided use _Field_ as wrapper in order to have the following props.
+
+| Prop (parameters) | Description                                     |
+| ----------------- | ----------------------------------------------- |
+| helpText          | String shown as text under the component        |
 | helpTextComponent | Custom component that replaces the one provided |
-| onPress | onPress method |
-
+| onPress           | onPress method                                  |
 
 ### Separator
+
 ```javascript
-  <Separator
-    label="Example" // optional: if present it will show the text
-    />
+<Separator
+  label="Example" // optional: if present it will show the text
+/>
 ```
 
 ### InputField
+
 Input fields can be used to receive text, you can add icons (a react component) to the left and the right side of the field.
 
-InputField can validate values based on keyboardType property, validation is not "aggressive", just changes a value inside the class, you can access the value using the ref (ex. this.ref.example_input_field.valid).  
-InputField automatically provides the attibutes _valid_ and _validationErrors_ to guarantee full control to the developer.
+InputField can validate values based on keyboardType property, validation is not "aggressive", just changes a value inside the class, you can access the value using the ref (ex. this.ref.example*input_field.valid).  
+InputField automatically provides the attibutes \_valid* and _validationErrors_ to guarantee full control to the developer.
 
 you can customize your validation function by adding a _validationFunction_ prop to the component. _validationFunction_ supports also an array of validators.
 
 #### Creating a validator
+
 Validators are simple functions have one paramenter (value) and that return true or a string containing an error.
 
 ```javascript
-let workingValidator = (value)=>{
-  if(value == '') return "Required";
+let workingValidator = value => {
+  if (value == "") return "Required";
   //Initial state is null/undefined
-  if(!value) return true;
+  if (!value) return true;
   var matches = value.match(/\d+/g);
   if (matches != null) {
     return "First Name can't contain numbers";
   }
 
   return true;
-}
+};
 ```
 
 _react-native-form-generator_ doesn't depend on any icon library, that gives you freedom of adding any icon or react component you want.
@@ -247,110 +269,120 @@ look at the example here.
 ![react-native-form-generator-inputfield](https://cloud.githubusercontent.com/assets/107390/12533401/1f6d1e7c-c1fd-11e5-96d0-aeba9a313ab9.gif)
 
 ```javascript
-  <InputField
-    label='Example' // if label is present the field is rendered with the value on the left (see First Name example in the gif), otherwise its rendered with textinput at full width (second name in the gif).
-    ref='example_input_field' // used in onChange event to collect the value
-    value='default_value' // used as initial value
-    keyboardType = '' // undefined, 'email-address',
-    validationFunction = {(value)=>{return true;}}
-    iconRight={
-      <Icon name='checkmark-circled'
-        size={30}
-        style={[
-          {marginTop:7, color:"#61d062" },
-          ((self)=>{
-            //i can change the style of the component related to the attibute of example_input_field
-            if(!!(self.refs && self.refs.example_input_field)){
-              if(!self.refs.example_input_field.valid) return {color:'#d52222'}
-            }
-            }
-          )(this)]}
-        />
-    }  //React Component
+<InputField
+  label="Example" // if label is present the field is rendered with the value on the left (see First Name example in the gif), otherwise its rendered with textinput at full width (second name in the gif).
+  ref="example_input_field" // used in onChange event to collect the value
+  value="default_value" // used as initial value
+  keyboardType="" // undefined, 'email-address',
+  validationFunction={value => {
+    return true;
+  }}
+  iconRight={
+    <Icon
+      name="checkmark-circled"
+      size={30}
+      style={[
+        { marginTop: 7, color: "#61d062" },
+        (self => {
+          //i can change the style of the component related to the attibute of example_input_field
+          if (!!(self.refs && self.refs.example_input_field)) {
+            if (!self.refs.example_input_field.valid)
+              return { color: "#d52222" };
+          }
+        })(this)
+      ]}
     />
+  } //React Component
+/>
 ```
+
 All the props are passed down to the underlying TextInput Component
 
-| Prop (parameters) | Description |
-| --- | --- |
-| label | Text to show in the field, if exists will move the textinput on the right, providing also the right alignment |
-| iconLeft | React component, shown on the left of the field, the component needs to have a prop size to allow the inputText to resize properly  |
-| iconRight | React component, shown on the right of the field, the component needs to have a prop size to allow the inputText to resize properly  |
-| validationFunction | Function or array of functions, used to pass custom validators to the component|
-| keyboardType | possible values: __underfined__, __email-address__|
+| Prop (parameters)  | Description                                                                                                                         |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------- |
+| label              | Text to show in the field, if exists will move the textinput on the right, providing also the right alignment                       |
+| iconLeft           | React component, shown on the left of the field, the component needs to have a prop size to allow the inputText to resize properly  |
+| iconRight          | React component, shown on the right of the field, the component needs to have a prop size to allow the inputText to resize properly |
+| validationFunction | Function or array of functions, used to pass custom validators to the component                                                     |
+| keyboardType       | possible values: **underfined**, **email-address**                                                                                  |
 
-| ref methods | Description |
-| --- | --- |
-| setValue | Sets the value programmatically |
-| focus | Focus the textinput component |
-
+| ref methods | Description                     |
+| ----------- | ------------------------------- |
+| setValue    | Sets the value programmatically |
+| focus       | Focus the textinput component   |
 
 ### SwitchField
 
-| Prop (parameters) | Description |
-| --- | --- |
-| onValueChange(value) | triggered at every value change, returns the new value of the field|
-| value | Initial value of the component (Boolean)|
-
+| Prop (parameters)    | Description                                                         |
+| -------------------- | ------------------------------------------------------------------- |
+| onValueChange(value) | triggered at every value change, returns the new value of the field |
+| value                | Initial value of the component (Boolean)                            |
 
 ### PickerField
-| Prop (parameters) | Description |
-| --- | --- |
-| onValueChange(value) | triggered at every value change, returns the new value of the field|
-| value | Initial value of the component|
-| options=[{label:"test",value="Test"},...] | All the possible options, array of objects|
-| iconRight | React component, shown on the left of the text field (i suggest Ionicons 'ios-arrow-right' for a nice iOS effect)  |
-| pickerWrapper | Optional, Custom wrapper of the picker, check the example  |
+
+| Prop (parameters)                         | Description                                                                                                       |
+| ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| onValueChange(value)                      | triggered at every value change, returns the new value of the field                                               |
+| value                                     | Initial value of the component                                                                                    |
+| options=[{label:"test",value="Test"},...] | All the possible options, array of objects                                                                        |
+| iconRight                                 | React component, shown on the left of the text field (i suggest Ionicons 'ios-arrow-right' for a nice iOS effect) |
+| pickerWrapper                             | Optional, Custom wrapper of the picker, check the example                                                         |
 
 ### DatePickerField
+
 Every prop is passed down to the underlying DatePickerIOS/DatePickerAndroid component.
 
-| Prop (parameters) | Description |
-| --- | --- |
-| onValueChange(date) | triggered at every value change, returns the new value of the field|
-| date | Initial date of the component, defaults to (new Date()) |
-| iconRight | React component, shown on the left of the text field (i suggest Ionicons 'ios-arrow-right' for a nice iOS effect)  |
-| dateTimeFormat | Optional, Custom date formatter |
-| pickerWrapper | Optional, Custom wrapper of the picker, check the example  |
-| prettyPrint | Boolean, if true the component returns a string formatted using dateTimeFormat, if false a Date object is returned |
-| placeholderComponent | Substitutes the component used to render the placeholder |
-| placeholderStyle | Used to style the placeholder |
-| valueStyle | Used to style the field's value |
+| Prop (parameters)    | Description                                                                                                        |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| onValueChange(date)  | triggered at every value change, returns the new value of the field                                                |
+| date                 | Initial date of the component, defaults to (new Date())                                                            |
+| iconRight            | React component, shown on the left of the text field (i suggest Ionicons 'ios-arrow-right' for a nice iOS effect)  |
+| dateTimeFormat       | Optional, Custom date formatter                                                                                    |
+| pickerWrapper        | Optional, Custom wrapper of the picker, check the example                                                          |
+| prettyPrint          | Boolean, if true the component returns a string formatted using dateTimeFormat, if false a Date object is returned |
+| placeholderComponent | Substitutes the component used to render the placeholder                                                           |
+| placeholderStyle     | Used to style the placeholder                                                                                      |
+| valueStyle           | Used to style the field's value                                                                                    |
 
 ### TimePickerField
+
 Every prop is passed down to the underlying DatePickerIOS/DatePickerAndroid component.
 Mode is set to 'time'
 
-| Prop (parameters) | Description |
-| --- | --- |
-| onValueChange(date) | triggered at every value change, returns the new value of the field|
-| date | Initial date of the component, defaults to (new Date()) |
-| iconRight | React component, shown on the left of the text field (i suggest Ionicons 'ios-arrow-right' for a nice iOS effect)  |
-| dateTimeFormat | Optional, Custom date formatter |
-| pickerWrapper | Optional, Custom wrapper of the picker, check the example  |
-| prettyPrint | Boolean, if true the component returns a string formatted using dateTimeFormat, if false a Date object is returned |
-| placeholderComponent | Substitutes the component used to render the placeholder |
-| placeholderStyle | Used to style the placeholder |
-| valueStyle | Used to style the field's value |
+| Prop (parameters)    | Description                                                                                                        |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| onValueChange(date)  | triggered at every value change, returns the new value of the field                                                |
+| date                 | Initial date of the component, defaults to (new Date())                                                            |
+| iconRight            | React component, shown on the left of the text field (i suggest Ionicons 'ios-arrow-right' for a nice iOS effect)  |
+| dateTimeFormat       | Optional, Custom date formatter                                                                                    |
+| pickerWrapper        | Optional, Custom wrapper of the picker, check the example                                                          |
+| prettyPrint          | Boolean, if true the component returns a string formatted using dateTimeFormat, if false a Date object is returned |
+| placeholderComponent | Substitutes the component used to render the placeholder                                                           |
+| placeholderStyle     | Used to style the placeholder                                                                                      |
+| valueStyle           | Used to style the field's value                                                                                    |
 
 ### LinkField
+
 Every prop is passed down to the underlying DatePickerIOS component.
 
-| Prop (parameters) | Description |
-| --- | --- |
-| label | Text to show in the field |
-| iconLeft | React component, shown on the left of the text field  |
-| iconRight | React component, shown on the left of the text field (i suggest Ionicons 'ios-arrow-right' for a nice iOS effect)  |
+| Prop (parameters) | Description                                                                                                       |
+| ----------------- | ----------------------------------------------------------------------------------------------------------------- |
+| label             | Text to show in the field                                                                                         |
+| iconLeft          | React component, shown on the left of the text field                                                              |
+| iconRight         | React component, shown on the left of the text field (i suggest Ionicons 'ios-arrow-right' for a nice iOS effect) |
 
 ### KeyboardEvents
+
 react-native-form-generator ships with an implementation ok KeyboardAwareScrollView that make handling keyboard events a breeze.
 check here https://medium.com/@michaelcereda/react-native-forms-the-right-way-315802f989d6#.p9oj79vt3
 
 ![react-native-form-generator-keyevents](https://cloud.githubusercontent.com/assets/107390/12499708/edb63838-c07a-11e5-9fe4-87979285ccc0.gif)
 
 ### Custom Fields
+
 With react-native-form-generator is extremely easy to create your own custom fields.
 You just need to know that:
+
 1. Every field is a react component
 2. Evey field will receive 3 props from the Form object:
    - fieldRef: contains the reference of the field (workaround on a react-native bug).
@@ -358,6 +390,7 @@ You just need to know that:
    - onValueChange: can be used whenever you prefer to pass the values to another component.
 
 Example
+
 ```javascript
 'use strict';
 import {Field} from '../lib/Field';
@@ -395,10 +428,13 @@ export class SimpleInputField extends React.Component{
 
 }
 ```
+
 ### Wrapping fields
+
 You can decide to wrap every field in a component to mantain design uniformity and avoid repetitions (ex. Icons ?!).
 
 Battle tested example
+
 ```javascript
 import {PickerField, LinkField} from 'react-native-form-generator';
 import Icon from 'react-native-vector-icons/Ionicons';

--- a/examples/FormView.js
+++ b/examples/FormView.js
@@ -3,76 +3,98 @@ This is a view i use in a test app,
 very useful to list all the use cases
 */
 
-import React from 'react';
+import React from "react";
 
 import {
-  AppRegistry,
-  StyleSheet,
   Text,
-  View,ScrollView,TouchableHighlight, Modal
-} from 'react-native';
-import Icon from 'react-native-vector-icons/Ionicons';
+  View,
+  ScrollView,
+  TouchableHighlight,
+  Modal
+} from "react-native";
+import Icon from "react-native-vector-icons/Ionicons";
 
+import {
+  Form,
+  Separator,
+  InputField,
+  LinkField,
+  SwitchField,
+  PickerField,
+  DatePickerField,
+  TimePickerField,
+  CountDownField
+} from "react-native-form-generator";
 
-
-import { Form,
-  Separator,InputField, LinkField,
-  SwitchField, PickerField, DatePickerField,
-  TimePickerField, CountDownField
-} from 'react-native-form-generator';
-
-class CustomModal extends React.Component{
-  handleClose(){
+class CustomModal extends React.Component {
+  handleClose() {
     this.props.onHidePicker && this.props.onHidePicker();
   }
-  render(){
-    return <Modal transparent={true}>
-    <View style={{padding:20, flex:1, justifyContent:'center', backgroundColor:'rgba(43, 48, 62, 0.57)'}}>
-    <View
-      style={{
-        backgroundColor:'white',
-        borderRadius: 8,
-        flexDirection:'column',
+  render() {
+    return (
+      <Modal transparent={true}>
+        <View
+          style={{
+            padding: 20,
+            flex: 1,
+            justifyContent: "center",
+            backgroundColor: "rgba(43, 48, 62, 0.57)"
+          }}
+        >
+          <View
+            style={{
+              backgroundColor: "white",
+              borderRadius: 8,
+              flexDirection: "column"
+            }}
+          >
+            <Text
+              style={{
+                textAlign: "center",
+                marginTop: 10,
+                paddingTop: 10,
+                paddingBottom: 10,
+                fontSize: 18
+              }}
+            >
+              A Custom Wrapper for your picker
+            </Text>
+            {this.props.children}
 
-    }}
-      >
-      <Text style={{
-        textAlign: 'center',
-        marginTop:10,
-        paddingTop:10,
-        paddingBottom:10,
-        fontSize:18
-      }}>A Custom Wrapper for your picker</Text>
-      {this.props.children}
-
-    <TouchableHighlight
-      onPress={this.handleClose.bind(this)}
-    underlayColor='#78ac05'>
-    <View style={{
-        flex:1, alignItems:'center'
-      }}><Text style={{fontSize:19,padding:15,}}>Close</Text></View></TouchableHighlight>
-      </View>
-      </View>
-    </Modal>
+            <TouchableHighlight
+              onPress={this.handleClose.bind(this)}
+              underlayColor="#78ac05"
+            >
+              <View
+                style={{
+                  flex: 1,
+                  alignItems: "center"
+                }}
+              >
+                <Text style={{ fontSize: 19, padding: 15 }}>Close</Text>
+              </View>
+            </TouchableHighlight>
+          </View>
+        </View>
+      </Modal>
+    );
   }
 }
 
 class WrappedIcon extends React.Component {
   render() {
-    return (
-      <Icon {...this.props} />
-    );
+    return <Icon {...this.props} />;
   }
 }
 
-export class FormView extends React.Component{
-  constructor(props){
+export class FormView extends React.Component {
+  constructor(props) {
     super(props);
     this.state = {
-      formData:{}
-    }
+      formData: {}
+    };
   }
-  handleFormChange(formData){
+  handleFormChange(formData) {
     /*
     formData will contain all the values of the form,
     in this example.
@@ -86,141 +108,234 @@ export class FormView extends React.Component{
     }
     */
 
-    this.setState({formData:formData})
+    this.setState({ formData: formData });
     this.props.onFormChange && this.props.onFormChange(formData);
   }
-  handleFormFocus(e, component){
+  handleFormFocus(e, component) {
     //console.log(e, component);
   }
-  openTermsAndConditionsURL(){
-
-  }
-  resetForm(){
-
+  openTermsAndConditionsURL() {}
+  resetForm() {
     this.refs.registrationForm.refs.first_name.setValue("");
     this.refs.registrationForm.refs.last_name.setValue("");
     this.refs.registrationForm.refs.other_input.setValue("");
     this.refs.registrationForm.refs.meeting.setDate(new Date());
     this.refs.registrationForm.refs.has_accepted_conditions.setValue(false);
   }
-  render(){
-
-
-
-    return (<ScrollView keyboardShouldPersistTaps={true} style={{ height:200}}>
-      <Form
-        ref='registrationForm'
-        onFocus={this.handleFormFocus.bind(this)}
-        onChange={this.handleFormChange.bind(this)}
-        label="Personal Information">
-        <Separator />
-        <InputField
-          ref='first_name'
-          label='First Name'
-          placeholder='First Name'
-          helpText={((self)=>{
-
-            if(Object.keys(self.refs).length !== 0){
-              if(!self.refs.registrationForm.refs.first_name.valid){
-                return self.refs.registrationForm.refs.first_name.validationErrors.join("\n");
+  render() {
+    return (
+      <ScrollView keyboardShouldPersistTaps={true} style={{ height: 200 }}>
+        <Form
+          ref="registrationForm"
+          onFocus={this.handleFormFocus.bind(this)}
+          onChange={this.handleFormChange.bind(this)}
+          label="Personal Information"
+        >
+          <Separator />
+          <InputField
+            ref="first_name"
+            label="First Name"
+            placeholder="First Name"
+            helpText={(self => {
+              if (Object.keys(self.refs).length !== 0) {
+                if (!self.refs.registrationForm.refs.first_name.valid) {
+                  return self.refs.registrationForm.refs.first_name.validationErrors.join(
+                    "\n"
+                  );
+                }
               }
-
-            }
-            // if(!!(self.refs && self.refs.first_name.valid)){
-            // }
-          })(this)}
-          validationFunction={[(value)=>{
-            /*
+              // if(!!(self.refs && self.refs.first_name.valid)){
+              // }
+            })(this)}
+            validationFunction={[
+              value => {
+                /*
             you can have multiple validators in a single function or an array of functions
              */
 
-            if(value == '') return "Required";
-            //Initial state is null/undefined
-            if(!value) return true;
-            var matches = value.match(/\d+/g);
-            if (matches != null) {
-                return "First Name can't contain numbers";
-            }
+                if (value == "") return "Required";
+                //Initial state is null/undefined
+                if (!value) return true;
+                var matches = value.match(/\d+/g);
+                if (matches != null) {
+                  return "First Name can't contain numbers";
+                }
 
-            return true;
-          }, (value)=>{
-            if(!value) return true;
-            if(value.indexOf('4')!=-1){
-              return "I can't stand number 4";
-            }
-            return true;
-          }]}
+                return true;
+              },
+              value => {
+                if (!value) return true;
+                if (value.indexOf("4") != -1) {
+                  return "I can't stand number 4";
+                }
+                return true;
+              }
+            ]}
           />
-        <InputField
-          iconLeft={<WrappedIcon style={{marginLeft:10, alignSelf:'center', color:'#793315'}} name='ios-american-football-outline' size={30} />}
-        ref='last_name' value="Default Value" placeholder='Last Name'/>
-        <InputField
-          multiline={true}
-          ref='other_input'
-          placeholder='Other Input'
-          helpText='this is an helpful text it can be also very very long and it will wrap' />
           <InputField
-            ref='email'
-            value='test@test.it'
-            keyboardType='email-address'
-            placeholder='Email fields'
-            helpTextComponent={<Text>Custom Help Text Component</Text>} />
-        <Separator />
-        <LinkField
-          label="LinkField, it acts like a button" onPress={()=>{}}
-          iconLeft={<Icon style={{marginLeft:10, alignSelf:'center', color:'#793315'}} name='ios-american-football-outline' size={30} />}
-          iconRight={<Icon style={{alignSelf:'center',marginRight:10, color:'#969696'}} name='ios-arrow-forward' size={30} />}
+            iconLeft={
+              <WrappedIcon
+                style={{
+                  marginLeft: 10,
+                  alignSelf: "center",
+                  color: "#793315"
+                }}
+                name="ios-american-football-outline"
+                size={30}
+              />
+            }
+            ref="last_name"
+            value="Default Value"
+            placeholder="Last Name"
           />
-        <SwitchField label='I accept Terms & Conditions'
-          ref="has_accepted_conditions"
-          helpText='Please read carefully the terms & conditions'/>
-        <PickerField ref='gender'
-          label='Gender'
-          value='female'
-          options={[{value:"", label: ""}, {value: "male", label:"Male"}, {value: "female", label:"Female"}]}
-
+          <InputField
+            multiline={true}
+            ref="other_input"
+            placeholder="Other Input"
+            helpText="this is an helpful text it can be also very very long and it will wrap"
           />
-          <DatePickerField ref='birthday'
-          minimumDate={new Date('1/1/1900')}
-          maximumDate={new Date()}
-          iconRight={[<Icon style={{alignSelf:'center', marginLeft:10}} name='ios-arrow-forward' size={30} />,
-                      <Icon style={{alignSelf:'center', marginLeft:10}} name='ios-arrow-down' size={30} />
-                      ]}
-          placeholder='Birthday'/>
-        <TimePickerField ref='alarm_time'
-      placeholder='Set Alarm'
-      iconLeft={<Icon style={{alignSelf:'center', marginLeft:10}} name='ios-alarm' size={30} />}
-      prettyPrint={true}
-      pickerWrapper={<CustomModal />}
-      />
-        <CountDownField ref='countdown'
-                        label="CountDown"
-                        placeholder='11:00' />
-        <DatePickerField ref='meeting'
-          iconLeft={[<Icon style={{alignSelf:'center', marginLeft:10}} name='ios-flame' size={30} />,
-                     <Icon style={{alignSelf:'center', marginLeft:10, color:'red'}} name='ios-flame' size={30} />
-                  ]}
-          minimumDate={new Date('1/1/1900')}
-          maximumDate={new Date()} mode="datetime" placeholder='Meeting'/>
+          <InputField
+            ref="email"
+            value="test@test.it"
+            keyboardType="email-address"
+            placeholder="Email fields"
+            helpTextComponent={<Text>Custom Help Text Component</Text>}
+          />
+          <Separator />
+          <LinkField
+            label="LinkField, it acts like a button"
+            onPress={() => {}}
+            iconLeft={
+              <Icon
+                style={{
+                  marginLeft: 10,
+                  alignSelf: "center",
+                  color: "#793315"
+                }}
+                name="ios-american-football-outline"
+                size={30}
+              />
+            }
+            iconRight={
+              <Icon
+                style={{
+                  alignSelf: "center",
+                  marginRight: 10,
+                  color: "#969696"
+                }}
+                name="ios-arrow-forward"
+                size={30}
+              />
+            }
+          />
+          <SwitchField
+            label="I accept Terms & Conditions"
+            ref="has_accepted_conditions"
+            helpText="Please read carefully the terms & conditions"
+          />
+          <PickerField
+            ref="gender"
+            label="Gender"
+            value="female"
+            options={[
+              { value: "", label: "" },
+              { value: "male", label: "Male" },
+              { value: "female", label: "Female" }
+            ]}
+          />
+          <DatePickerField
+            ref="birthday"
+            minimumDate={new Date("1/1/1900")}
+            maximumDate={new Date()}
+            iconRight={[
+              <Icon
+                style={{ alignSelf: "center", marginLeft: 10 }}
+                name="ios-arrow-forward"
+                size={30}
+              />,
+              <Icon
+                style={{ alignSelf: "center", marginLeft: 10 }}
+                name="ios-arrow-down"
+                size={30}
+              />
+            ]}
+            placeholder="Birthday"
+          />
+          <TimePickerField
+            ref="alarm_time"
+            placeholder="Set Alarm"
+            iconLeft={
+              <Icon
+                style={{ alignSelf: "center", marginLeft: 10 }}
+                name="ios-alarm"
+                size={30}
+              />
+            }
+            prettyPrint={true}
+            pickerWrapper={<CustomModal />}
+          />
+          <CountDownField
+            ref="countdown"
+            label="CountDown"
+            placeholder="11:00"
+          />
+          <DatePickerField
+            ref="meeting"
+            iconLeft={[
+              <Icon
+                style={{ alignSelf: "center", marginLeft: 10 }}
+                name="ios-flame"
+                size={30}
+              />,
+              <Icon
+                style={{ alignSelf: "center", marginLeft: 10, color: "red" }}
+                name="ios-flame"
+                size={30}
+              />
+            ]}
+            minimumDate={new Date("1/1/1900")}
+            maximumDate={new Date()}
+            mode="datetime"
+            placeholder="Meeting"
+          />
         </Form>
         <Text>{JSON.stringify(this.state.formData)}</Text>
-      <TouchableHighlight
-        onPress={this.resetForm.bind(this)}
-      underlayColor='#78ac05'>
-      <View style={[{
-          flex:1, alignItems:'center'
-        }
-      ]}><Text style={{fontSize:19,padding:15,}}>Reset</Text></View></TouchableHighlight>
-      <TouchableHighlight
-      disabled={!this.state.formData.has_accepted_conditions}
-      onPress={()=>this.refs.registrationForm.refs.other_input.focus()}
-      underlayColor='#78ac05'>
-      <View style={[{
-          flex:1, alignItems:'center',
-          borderColor:(this.state.formData.has_accepted_conditions)?'#2398c9':'grey',
-          borderWidth:5
-        },
-      ]}><Text style={{fontSize:19,padding:15,}}>Focus First Name</Text></View></TouchableHighlight>
-      </ScrollView>);
-    }
+        <TouchableHighlight
+          onPress={this.resetForm.bind(this)}
+          underlayColor="#78ac05"
+        >
+          <View
+            style={[
+              {
+                flex: 1,
+                alignItems: "center"
+              }
+            ]}
+          >
+            <Text style={{ fontSize: 19, padding: 15 }}>Reset</Text>
+          </View>
+        </TouchableHighlight>
+        <TouchableHighlight
+          disabled={!this.state.formData.has_accepted_conditions}
+          onPress={() => this.refs.registrationForm.refs.other_input.focus()}
+          underlayColor="#78ac05"
+        >
+          <View
+            style={[
+              {
+                flex: 1,
+                alignItems: "center",
+                borderColor: this.state.formData.has_accepted_conditions
+                  ? "#2398c9"
+                  : "grey",
+                borderWidth: 5
+              }
+            ]}
+          >
+            <Text style={{ fontSize: 19, padding: 15 }}>Focus First Name</Text>
+          </View>
+        </TouchableHighlight>
+      </ScrollView>
+    );
   }
+}

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 "use strict";
 
-import { Form as _Form } from "./src/Form";
+import { Form } from "./src/Form";
 import { Separator } from "./src/fields/Separator";
 import { InputField } from "./src/fields/InputField";
 import { LinkField } from "./src/fields/LinkField";
@@ -10,10 +10,6 @@ import { DatePickerField } from "./src/fields/DatePickerField";
 import { TimePickerField } from "./src/fields/TimePickerField";
 // Following not supported by android / windows
 // import {CountDownField} from './src/fields/CountDownField';
-
-import { TestPathContainer } from "@axsy-dev/testable";
-
-const Form = TestPathContainer(_Form, "Form");
 
 export {
   Form,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.9.36",
       "license": "MIT",
       "dependencies": {
+        "@react-native-picker/picker": "^2.2.1",
         "lodash": "^4.17.11",
         "moment": "^2.24.0",
         "moment-range": "3.0.0",
@@ -24,7 +25,6 @@
         "prettier": "^2.6.2"
       },
       "peerDependencies": {
-        "@axsy-dev/testable": "^1.0.15",
         "@react-native-community/datetimepicker": "^3.0.2"
       }
     },
@@ -972,6 +972,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@react-native-picker/picker": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@react-native-picker/picker/-/picker-2.4.2.tgz",
+      "integrity": "sha512-0nY8638h1J3wKz6P3IJMpOoxJDdOj7Dk/K2hP/xpqP3KnIY0lmoqYlhyNihuyVPocDGajf6SA7LFFsFepQ56ag==",
+      "peerDependencies": {
+        "react": "16 || 17",
+        "react-native": ">=0.57"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -5214,6 +5223,11 @@
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
+    },
+    "@react-native-picker/picker": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@react-native-picker/picker/-/picker-2.4.2.tgz",
+      "integrity": "sha512-0nY8638h1J3wKz6P3IJMpOoxJDdOj7Dk/K2hP/xpqP3KnIY0lmoqYlhyNihuyVPocDGajf6SA7LFFsFepQ56ag=="
     },
     "@sinclair/typebox": {
       "version": "0.23.5",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "url": "info@michaelcereda.com"
   },
   "dependencies": {
+    "@react-native-picker/picker": "^2.2.1",
     "lodash": "^4.17.11",
     "moment": "^2.24.0",
     "moment-range": "3.0.0",
@@ -24,7 +25,6 @@
   "main": "index.js",
   "name": "@axsy-dev/react-native-form-generator",
   "peerDependencies": {
-    "@axsy-dev/testable": "^1.0.15",
     "@react-native-community/datetimepicker": "^3.0.2"
   },
   "lint-staged": {
@@ -39,7 +39,7 @@
     "test:watch": "jest --watchAll",
     "format": "prettier --write --loglevel=silent"
   },
-  "version": "0.9.36",
+  "version": "0.9.37",
   "devDependencies": {
     "@tsconfig/react-native": "^1.0.4",
     "@types/react": "^17.0.39",

--- a/src/Form.js
+++ b/src/Form.js
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import { View } from "react-native";
+import { Text, View } from "react-native";
 
 export class Form extends Component {
   constructor(props) {
@@ -39,7 +39,6 @@ export class Form extends Component {
   }
 
   render() {
-    const { tidRoot } = this.props;
     let wrappedChildren = [];
 
     React.Children.map(
@@ -49,7 +48,6 @@ export class Form extends Component {
           return;
         }
         const isTestable = this.props.hasTestableWrappers === true;
-        const tidRoot = isTestable ? child.props.testID : `Element[${i}]`
         let formElement = isTestable ? child.props.children : child;
         formElement = React.cloneElement(formElement, {
           key: formElement.props.fieldKey
@@ -57,7 +55,6 @@ export class Form extends Component {
             : formElement.type + i,
           fieldRef: formElement.ref,
           ref: formElement.ref,
-          tidRoot: `${tidRoot ?? ""}`,
           onFocus: this.handleFieldFocused.bind(this),
           onChange: this.handleFieldChange.bind(this, formElement.ref)
         });
@@ -75,6 +72,10 @@ export class Form extends Component {
       this
     );
 
-    return <View testID={`${tidRoot ?? ""}/Form`} style={this.props.style}>{wrappedChildren}</View>;
+    return (
+      <View testID={`Form`} style={this.props.style}>
+        {wrappedChildren}
+      </View>
+    );
   }
 }

--- a/src/Form.js
+++ b/src/Form.js
@@ -73,7 +73,7 @@ export class Form extends Component {
     );
 
     return (
-      <View testID={`Form`} style={this.props.style}>
+      <View testID="Form" style={this.props.style}>
         {wrappedChildren}
       </View>
     );

--- a/src/Form.js
+++ b/src/Form.js
@@ -47,7 +47,7 @@ export class Form extends Component {
   }
 
   render() {
-    let wrappedChildren = [];
+    let wrappedChildren = [(<Text>this is in the dev one!</Text>)];
 
     React.Children.map(
       this.props.children,
@@ -55,17 +55,17 @@ export class Form extends Component {
         if (!child) {
           return;
         }
-
         const isTestable = this.props.hasTestableWrappers === true;
+        const { tidRoot, field } = child.props;
 
         let formElement = isTestable ? child.props.children : child;
-
         formElement = React.cloneElement(formElement, {
           key: formElement.props.fieldKey
             ? formElement.props.fieldKey
             : formElement.type + i,
           fieldRef: formElement.ref,
           ref: formElement.ref,
+          tidRoot: `${tidRoot && `${tidRoot}/`}Field[${field?.name || "Unknown"}:${field?.type || "Unknown"}]`,
           onFocus: this.handleFieldFocused.bind(this),
           onChange: this.handleFieldChange.bind(this, formElement.ref)
         });

--- a/src/Form.js
+++ b/src/Form.js
@@ -1,13 +1,5 @@
 import React, { Component } from "react";
-import {
-  View,
-  TextInput,
-  StyleSheet,
-  ScrollView,
-  Text,
-  SliderIOS,
-  TouchableWithoutFeedback
-} from "react-native";
+import { View } from "react-native";
 
 export class Form extends Component {
   constructor(props) {
@@ -47,7 +39,8 @@ export class Form extends Component {
   }
 
   render() {
-    let wrappedChildren = [(<Text>this is in the dev one!</Text>)];
+    const { tidRoot } = this.props;
+    let wrappedChildren = [];
 
     React.Children.map(
       this.props.children,
@@ -56,8 +49,7 @@ export class Form extends Component {
           return;
         }
         const isTestable = this.props.hasTestableWrappers === true;
-        const { tidRoot, field } = child.props;
-
+        const tidRoot = isTestable ? child.props.testID : `Element[${i}]`
         let formElement = isTestable ? child.props.children : child;
         formElement = React.cloneElement(formElement, {
           key: formElement.props.fieldKey
@@ -65,7 +57,7 @@ export class Form extends Component {
             : formElement.type + i,
           fieldRef: formElement.ref,
           ref: formElement.ref,
-          tidRoot: `${tidRoot && `${tidRoot}/`}Field[${field?.name || "Unknown"}:${field?.type || "Unknown"}]`,
+          tidRoot: `${tidRoot ?? ""}`,
           onFocus: this.handleFieldFocused.bind(this),
           onChange: this.handleFieldChange.bind(this, formElement.ref)
         });
@@ -83,6 +75,6 @@ export class Form extends Component {
       this
     );
 
-    return <View style={this.props.style}>{wrappedChildren}</View>;
+    return <View testID={`${tidRoot ?? ""}/Form`} style={this.props.style}>{wrappedChildren}</View>;
   }
 }

--- a/src/fields/LinkField.android.js
+++ b/src/fields/LinkField.android.js
@@ -1,7 +1,6 @@
 "use strict";
 
 import React from "react";
-let { View, StyleSheet, TextInput, Text } = require("react-native");
 import { LinkComponent } from "../lib/LinkComponent";
 
 export class LinkField extends React.Component {

--- a/src/fields/LinkField.ios.js
+++ b/src/fields/LinkField.ios.js
@@ -1,7 +1,6 @@
 "use strict";
 
 import React from "react";
-let { View, StyleSheet, TextInput, Text } = require("react-native");
 import { LinkComponent } from "../lib/LinkComponent";
 
 export class LinkField extends React.Component {

--- a/src/fields/LinkField.windows.js
+++ b/src/fields/LinkField.windows.js
@@ -1,7 +1,6 @@
 "use strict";
 
 import React from "react";
-let { View, StyleSheet, TextInput, Text } = require("react-native");
 import { LinkComponent } from "../lib/LinkComponent";
 
 export class LinkField extends React.Component {

--- a/src/fields/SwitchField.android.js
+++ b/src/fields/SwitchField.android.js
@@ -1,7 +1,6 @@
 "use strict";
 
 import React from "react";
-let { View, StyleSheet, Text, Switch } = require("react-native");
 
 import { SwitchComponent } from "../lib/SwitchComponent";
 

--- a/src/fields/SwitchField.ios.js
+++ b/src/fields/SwitchField.ios.js
@@ -1,7 +1,6 @@
 "use strict";
 
 import React from "react";
-let { View, StyleSheet, Text, Switch } = require("react-native");
 
 import { SwitchComponent } from "../lib/SwitchComponent";
 

--- a/src/fields/SwitchField.windows.js
+++ b/src/fields/SwitchField.windows.js
@@ -1,7 +1,6 @@
 "use strict";
 
 import React from "react";
-let { View, StyleSheet, Text, Switch } = require("react-native");
 
 import { SwitchComponent } from "../lib/SwitchComponent";
 

--- a/src/lib/DatePickerComponent.android.js
+++ b/src/lib/DatePickerComponent.android.js
@@ -2,11 +2,10 @@
 
 import React from "react";
 import PropTypes from "prop-types";
-let { View, StyleSheet, TextInput, Button } = require("react-native");
+let { View, Text } = require("react-native");
 import DateTimePicker from "@react-native-community/datetimepicker";
 import { Field } from "./Field";
 
-import { TestPathSegment, TText } from "@axsy-dev/testable";
 import {
   formatDateResult,
   normalizeAndFormat,
@@ -152,76 +151,74 @@ export class DatePickerComponent extends React.Component {
   }
 
   render() {
-    const { placeholderComponent, iconClear, iconRight, iconLeft } = this.props;
+    const { placeholderComponent, iconClear, iconRight, iconLeft, tidRoot } = this.props;
 
     const valueString = this.state.date
       ? this.props.dateTimeFormat(this.state.date, this.props.mode)
       : "";
 
     const timeValue = this.state.date || new Date();
-    const valueTestId = this.state.date
+    const valueTestId = `${tidRoot ?? ""}/` + (this.state.date
       ? `Value[${this.state.date.getTime()}]`
-      : "Value[unknown]";
+      : "Value[unknown]");
 
     return (
-      <TestPathSegment name={`Field[${this.props.fieldRef}]` || "DatePicker"}>
-        <View>
-          <Field {...this.props} ref="inputBox" onPress={this._togglePicker}>
-            <View
-              style={this.props.containerStyle}
-              onLayout={this.handleLayoutChange}
-            >
-              {iconLeft ? iconLeft : null}
-              {placeholderComponent ? (
-                placeholderComponent
-              ) : (
-                <DatePickerPlaceholder {...this.props} />
-              )}
-              <View style={this.props.valueContainerStyle}>
-                <TText tid={valueTestId} style={this.props.valueStyle}>
-                  {valueString}
-                </TText>
-                {iconClear && valueString ? (
-                  <TouchableContainer
-                    tid="ClearDateValue"
-                    onPress={this.handleClear}
-                  >
-                    {iconClear}
-                  </TouchableContainer>
-                ) : null}
-                {iconRight ? (
-                  <TouchableContainer
-                    tid="ToggleDatePicker"
-                    onPress={this._togglePicker}
-                  >
-                    {iconRight}
-                  </TouchableContainer>
-                ) : null}
-              </View>
+      <View>
+        <Field {...this.props} ref="inputBox" onPress={this._togglePicker}>
+          <View
+            style={this.props.containerStyle}
+            onLayout={this.handleLayoutChange}
+          >
+            {iconLeft ? iconLeft : null}
+            {placeholderComponent ? (
+              placeholderComponent
+            ) : (
+              <DatePickerPlaceholder {...this.props} />
+            )}
+            <View style={this.props.valueContainerStyle}>
+              <Text testID={valueTestId} style={this.props.valueStyle}>
+                {valueString}
+              </Text>
+              {iconClear && valueString ? (
+                <TouchableContainer
+                  tid={`${tidRoot ?? ""}/ClearDateValue`}
+                  onPress={this.handleClear}
+                >
+                  {iconClear}
+                </TouchableContainer>
+              ) : null}
+              {iconRight ? (
+                <TouchableContainer
+                  tid={`${tidRoot ?? ""}/ToggleDatePicker`}
+                  onPress={this._togglePicker}
+                >
+                  {iconRight}
+                </TouchableContainer>
+              ) : null}
             </View>
-          </Field>
-          {this.state.isDatePickerVisible ? (
-            <DateTimePicker
-              {...this.props}
-              mode="date"
-              value={timeValue}
-              minDate={this.props.minimumDate}
-              maxDate={this.props.maximumDate}
-              onChange={this.handleDateValueChange}
-            />
-          ) : null}
-          {this.state.isTimePickerVisible ? (
-            <DateTimePicker
-              {...this.props}
-              mode="time"
-              value={timeValue}
-              minDate={this.props.minimumDate}
-              maxDate={this.props.maximumDate}
-              onChange={this.handleTimeValueChange}
-            />
-          ) : null}
-        </View>
-      </TestPathSegment>
+          </View>
+        </Field>
+        {this.state.isDatePickerVisible ? (
+          <DateTimePicker
+            {...this.props}
+            mode="date"
+            value={timeValue}
+            minDate={this.props.minimumDate}
+            maxDate={this.props.maximumDate}
+            onChange={this.handleDateValueChange}
+          />
+        ) : null}
+        {this.state.isTimePickerVisible ? (
+          <DateTimePicker
+            {...this.props}
+            mode="time"
+            value={timeValue}
+            minDate={this.props.minimumDate}
+            maxDate={this.props.maximumDate}
+            onChange={this.handleTimeValueChange}
+          />
+        ) : null}
+      </View>
     );
   }
 }

--- a/src/lib/DatePickerComponent.android.js
+++ b/src/lib/DatePickerComponent.android.js
@@ -151,16 +151,18 @@ export class DatePickerComponent extends React.Component {
   }
 
   render() {
-    const { placeholderComponent, iconClear, iconRight, iconLeft, tidRoot } = this.props;
+    const { placeholderComponent, iconClear, iconRight, iconLeft } = this.props;
 
     const valueString = this.state.date
       ? this.props.dateTimeFormat(this.state.date, this.props.mode)
       : "";
 
     const timeValue = this.state.date || new Date();
-    const valueTestId = `${tidRoot ?? ""}/` + (this.state.date
-      ? `Value[${this.state.date.getTime()}]`
-      : "Value[unknown]");
+
+    const valueTestId =
+      `Value/` + this.state.date
+        ? `Value/${this.state.date?.getTime()}`
+        : "Unknown";
 
     return (
       <View>
@@ -181,7 +183,7 @@ export class DatePickerComponent extends React.Component {
               </Text>
               {iconClear && valueString ? (
                 <TouchableContainer
-                  tid={`${tidRoot ?? ""}/ClearDateValue`}
+                  tid={`ClearDateValue`}
                   onPress={this.handleClear}
                 >
                   {iconClear}
@@ -189,7 +191,7 @@ export class DatePickerComponent extends React.Component {
               ) : null}
               {iconRight ? (
                 <TouchableContainer
-                  tid={`${tidRoot ?? ""}/ToggleDatePicker`}
+                  tid={`ToggleDatePicker`}
                   onPress={this._togglePicker}
                 >
                   {iconRight}

--- a/src/lib/DatePickerComponent.android.js
+++ b/src/lib/DatePickerComponent.android.js
@@ -159,10 +159,9 @@ export class DatePickerComponent extends React.Component {
 
     const timeValue = this.state.date || new Date();
 
-    const valueTestId =
-      this.state.date
-        ? `Value/${this.state.date?.getTime()}`
-        : "Unknown";
+    const valueTestId = this.state.date
+      ? `Value/${this.state.date?.getTime()}`
+      : "Unknown";
 
     return (
       <View>

--- a/src/lib/DatePickerComponent.android.js
+++ b/src/lib/DatePickerComponent.android.js
@@ -2,7 +2,7 @@
 
 import React from "react";
 import PropTypes from "prop-types";
-let { View, Text } = require("react-native");
+import { View, Text } from "react-native";
 import DateTimePicker from "@react-native-community/datetimepicker";
 import { Field } from "./Field";
 
@@ -160,7 +160,7 @@ export class DatePickerComponent extends React.Component {
     const timeValue = this.state.date || new Date();
 
     const valueTestId =
-      `Value/` + this.state.date
+      this.state.date
         ? `Value/${this.state.date?.getTime()}`
         : "Unknown";
 

--- a/src/lib/DatePickerComponent.ios.js
+++ b/src/lib/DatePickerComponent.ios.js
@@ -143,20 +143,18 @@ export class DatePickerComponent extends React.Component {
   }
 
   render() {
-    const {
-      placeholderComponent,
-      iconClear,
-      tidRoot
-    } = this.props;
+    const { placeholderComponent, iconClear } = this.props;
 
-    const valueString = `${tidRoot ?? ""}/` + this.state.date
+    const valueString = this.state.date
       ? this.props.dateTimeFormat(this.state.date, this.props.mode)
-      : "Unknown";
+      : "";
 
+    const valueTestId =
+      `Value/` + this.state.date
+        ? `Value/${this.state.date?.getTime()}`
+        : "Unknown";
     const iconLeft = getIcon(this.state.isPickerVisible, this.props.iconLeft);
     const iconRight = getIcon(this.state.isPickerVisible, this.props.iconRight);
-
-    const valueTestId = "Value";
 
     return (
       <View>
@@ -177,7 +175,7 @@ export class DatePickerComponent extends React.Component {
               </Text>
               {iconClear && valueString ? (
                 <TouchableContainer
-                  tid={`${tidRoot ?? ""}/RemoveDateValue`}
+                  tid={`RemoveDateValue`}
                   onPress={this.handleClear}
                 >
                   {iconClear}
@@ -185,7 +183,7 @@ export class DatePickerComponent extends React.Component {
               ) : null}
               {iconRight ? (
                 <TouchableContainer
-                  tid={`${tidRoot ?? ""}/ToggleDatePicker`}
+                  tid={`ToggleDatePicker`}
                   onPress={this._togglePicker}
                 >
                   {iconRight}

--- a/src/lib/DatePickerComponent.ios.js
+++ b/src/lib/DatePickerComponent.ios.js
@@ -2,11 +2,10 @@
 
 import React from "react";
 import PropTypes from "prop-types";
-import { View, Text, Button } from "react-native";
+import { View, Text } from "react-native";
 import { Field } from "./Field";
 
 import DateTimePicker from "@react-native-community/datetimepicker";
-import { TestPathSegment, TText, TTouchableOpacity } from "@axsy-dev/testable";
 import {
   formatDateResult,
   normalizeAndFormat,
@@ -144,20 +143,15 @@ export class DatePickerComponent extends React.Component {
   }
 
   render() {
-    let {
-      maximumDate,
-      minimumDate,
-      minuteInterval,
-      mode,
-      onDateChange,
-      timeZoneOffsetInMinutes,
+    const {
       placeholderComponent,
-      iconClear
+      iconClear,
+      tidRoot
     } = this.props;
 
-    const valueString = this.state.date
+    const valueString = `${tidRoot ?? ""}/` + this.state.date
       ? this.props.dateTimeFormat(this.state.date, this.props.mode)
-      : "";
+      : "Unknown";
 
     const iconLeft = getIcon(this.state.isPickerVisible, this.props.iconLeft);
     const iconRight = getIcon(this.state.isPickerVisible, this.props.iconRight);
@@ -165,45 +159,43 @@ export class DatePickerComponent extends React.Component {
     const valueTestId = "Value";
 
     return (
-      <TestPathSegment name={`Field[${this.props.fieldRef}]` || "DatePicker"}>
-        <View>
-          <Field {...this.props} ref="inputBox" onPress={this._togglePicker}>
-            <View
-              style={[this.props.containerStyle]}
-              onLayout={this.handleLayoutChange}
-            >
-              {iconLeft ? iconLeft : null}
-              {placeholderComponent ? (
-                placeholderComponent
-              ) : (
-                <DatePickerPlaceholder {...this.props} />
-              )}
-              <View style={[this.props.valueContainerStyle]}>
-                <TText tid={valueTestId} style={[this.props.valueStyle]}>
-                  {valueString}
-                </TText>
-                {iconClear && valueString ? (
-                  <TouchableContainer
-                    tid="RemoveDateValue"
-                    onPress={this.handleClear}
-                  >
-                    {iconClear}
-                  </TouchableContainer>
-                ) : null}
-                {iconRight ? (
-                  <TouchableContainer
-                    tid="ToggleDatePicker"
-                    onPress={this._togglePicker}
-                  >
-                    {iconRight}
-                  </TouchableContainer>
-                ) : null}
-              </View>
+      <View>
+        <Field {...this.props} ref="inputBox" onPress={this._togglePicker}>
+          <View
+            style={[this.props.containerStyle]}
+            onLayout={this.handleLayoutChange}
+          >
+            {iconLeft ? iconLeft : null}
+            {placeholderComponent ? (
+              placeholderComponent
+            ) : (
+              <DatePickerPlaceholder {...this.props} />
+            )}
+            <View style={[this.props.valueContainerStyle]}>
+              <Text tid={valueTestId} style={[this.props.valueStyle]}>
+                {valueString}
+              </Text>
+              {iconClear && valueString ? (
+                <TouchableContainer
+                  tid={`${tidRoot ?? ""}/RemoveDateValue`}
+                  onPress={this.handleClear}
+                >
+                  {iconClear}
+                </TouchableContainer>
+              ) : null}
+              {iconRight ? (
+                <TouchableContainer
+                  tid={`${tidRoot ?? ""}/ToggleDatePicker`}
+                  onPress={this._togglePicker}
+                >
+                  {iconRight}
+                </TouchableContainer>
+              ) : null}
             </View>
-          </Field>
-          {this.state.isPickerVisible ? this._renderContent() : null}
-        </View>
-      </TestPathSegment>
+          </View>
+        </Field>
+        {this.state.isPickerVisible ? this._renderContent() : null}
+      </View>
     );
   }
 }

--- a/src/lib/DatePickerComponent.ios.js
+++ b/src/lib/DatePickerComponent.ios.js
@@ -149,10 +149,9 @@ export class DatePickerComponent extends React.Component {
       ? this.props.dateTimeFormat(this.state.date, this.props.mode)
       : "";
 
-    const valueTestId =
-      `Value/` + this.state.date
-        ? `Value/${this.state.date?.getTime()}`
-        : "Unknown";
+    const valueTestId = this.state.date
+      ? `Value/${this.state.date?.getTime()}`
+      : "Unknown";
     const iconLeft = getIcon(this.state.isPickerVisible, this.props.iconLeft);
     const iconRight = getIcon(this.state.isPickerVisible, this.props.iconRight);
 

--- a/src/lib/DatePickerComponent.windows.js
+++ b/src/lib/DatePickerComponent.windows.js
@@ -179,10 +179,9 @@ export class DatePickerComponent extends React.Component {
       ? { width: 300, opacity: 1, height: 30, marginTop: 10 }
       : {};
 
-    const valueTestId =
-      this.state.date
-        ? `Value/${this.state.date?.getTime()}`
-        : "Unknown";
+    const valueTestId = this.state.date
+      ? `Value/${this.state.date?.getTime()}`
+      : "Unknown";
 
     return (
       <View>

--- a/src/lib/DatePickerComponent.windows.js
+++ b/src/lib/DatePickerComponent.windows.js
@@ -3,11 +3,10 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-let { View, StyleSheet, TextInput } = require("react-native");
+let { View, Text } = require("react-native");
 
 import DateTimePicker from "@react-native-community/datetimepicker";
 import { Field } from "./Field";
-import { TestPathSegment, TText } from "@axsy-dev/testable";
 import {
   formatDateResult,
   normalizeAndFormat,
@@ -166,7 +165,7 @@ export class DatePickerComponent extends React.Component {
   }
 
   render() {
-    const { placeholderComponent, iconRight, iconClear } = this.props;
+    const { placeholderComponent, iconRight, iconClear, tidRoot } = this.props;
     const valueString = this.state.date
       ? this.props.dateTimeFormat(this.state.date, this.props.mode)
       : "";
@@ -182,7 +181,6 @@ export class DatePickerComponent extends React.Component {
     const valueTestId = "Value";
 
     return (
-      <TestPathSegment name={`Field[${this.props.fieldRef}]` || "DatePicker"}>
         <View>
           <Field {...this.props} ref="inputBox" onPress={this._togglePicker}>
             <View
@@ -196,12 +194,12 @@ export class DatePickerComponent extends React.Component {
                 <DatePickerPlaceholder {...this.props} />
               )}
               <View style={this.props.valueContainerStyle}>
-                <TText tid="Value" style={this.props.valueStyle}>
+                <Text testID={`${tidRoot ?? ""}/Value`} style={this.props.valueStyle}>
                   {valueString}
-                </TText>
+                </Text>
                 {iconClear && valueString ? (
                   <TouchableContainer
-                    tid="ClearDateValue"
+                    tid={`${tidRoot ?? ""}/ClearDateValue`}
                     onPress={this.handleClear}
                   >
                     {iconClear}
@@ -209,7 +207,7 @@ export class DatePickerComponent extends React.Component {
                 ) : null}
                 {iconRight ? (
                   <TouchableContainer
-                    tid="ToggleDatePicker"
+                    tid={`${tidRoot ?? ""}/ToggleDatePicker`}
                     onPress={this._togglePicker}
                   >
                     {iconRight}
@@ -234,7 +232,6 @@ export class DatePickerComponent extends React.Component {
             />
           ) : null}
         </View>
-      </TestPathSegment>
     );
   }
 }

--- a/src/lib/DatePickerComponent.windows.js
+++ b/src/lib/DatePickerComponent.windows.js
@@ -3,7 +3,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-let { View, Text } = require("react-native");
+import { View, Text } from "react-native";
 
 import DateTimePicker from "@react-native-community/datetimepicker";
 import { Field } from "./Field";
@@ -180,7 +180,7 @@ export class DatePickerComponent extends React.Component {
       : {};
 
     const valueTestId =
-      `Value/` + this.state.date
+      this.state.date
         ? `Value/${this.state.date?.getTime()}`
         : "Unknown";
 

--- a/src/lib/DatePickerComponent.windows.js
+++ b/src/lib/DatePickerComponent.windows.js
@@ -165,7 +165,7 @@ export class DatePickerComponent extends React.Component {
   }
 
   render() {
-    const { placeholderComponent, iconRight, iconClear, tidRoot } = this.props;
+    const { placeholderComponent, iconRight, iconClear } = this.props;
     const valueString = this.state.date
       ? this.props.dateTimeFormat(this.state.date, this.props.mode)
       : "";
@@ -178,60 +178,64 @@ export class DatePickerComponent extends React.Component {
     const pickerStyle = this.state.isTimePickerVisible
       ? { width: 300, opacity: 1, height: 30, marginTop: 10 }
       : {};
-    const valueTestId = "Value";
+
+    const valueTestId =
+      `Value/` + this.state.date
+        ? `Value/${this.state.date?.getTime()}`
+        : "Unknown";
 
     return (
-        <View>
-          <Field {...this.props} ref="inputBox" onPress={this._togglePicker}>
-            <View
-              style={this.props.containerStyle}
-              onLayout={this.handleLayoutChange}
-            >
-              {this.props.iconLeft ? this.props.iconLeft : null}
-              {placeholderComponent ? (
-                placeholderComponent
-              ) : (
-                <DatePickerPlaceholder {...this.props} />
-              )}
-              <View style={this.props.valueContainerStyle}>
-                <Text testID={`${tidRoot ?? ""}/Value`} style={this.props.valueStyle}>
-                  {valueString}
-                </Text>
-                {iconClear && valueString ? (
-                  <TouchableContainer
-                    tid={`${tidRoot ?? ""}/ClearDateValue`}
-                    onPress={this.handleClear}
-                  >
-                    {iconClear}
-                  </TouchableContainer>
-                ) : null}
-                {iconRight ? (
-                  <TouchableContainer
-                    tid={`${tidRoot ?? ""}/ToggleDatePicker`}
-                    onPress={this._togglePicker}
-                  >
-                    {iconRight}
-                  </TouchableContainer>
-                ) : null}
-              </View>
+      <View>
+        <Field {...this.props} ref="inputBox" onPress={this._togglePicker}>
+          <View
+            style={this.props.containerStyle}
+            onLayout={this.handleLayoutChange}
+          >
+            {this.props.iconLeft ? this.props.iconLeft : null}
+            {placeholderComponent ? (
+              placeholderComponent
+            ) : (
+              <DatePickerPlaceholder {...this.props} />
+            )}
+            <View style={this.props.valueContainerStyle}>
+              <Text testID={valueTestId} style={this.props.valueStyle}>
+                {valueString}
+              </Text>
+              {iconClear && valueString ? (
+                <TouchableContainer
+                  tid={`ClearDateValue`}
+                  onPress={this.handleClear}
+                >
+                  {iconClear}
+                </TouchableContainer>
+              ) : null}
+              {iconRight ? (
+                <TouchableContainer
+                  tid={`ToggleDatePicker`}
+                  onPress={this._togglePicker}
+                >
+                  {iconRight}
+                </TouchableContainer>
+              ) : null}
             </View>
-          </Field>
-          {isPickerVisible ? (
-            <DateTimePicker
-              {...this.props}
-              mode={pickerMode}
-              value={timeValue}
-              style={pickerStyle}
-              minDate={this.props.minimumDate}
-              maxDate={this.props.maximumDate}
-              is24Hour={false}
-              dateFormat={"month day year"}
-              minuteInterval={5}
-              onChange={this.onChange}
-              timeZoneOffsetInSeconds={0} // This is necessary since DateTimePicker for some reason adds -1 hr timezone offset
-            />
-          ) : null}
-        </View>
+          </View>
+        </Field>
+        {isPickerVisible ? (
+          <DateTimePicker
+            {...this.props}
+            mode={pickerMode}
+            value={timeValue}
+            style={pickerStyle}
+            minDate={this.props.minimumDate}
+            maxDate={this.props.maximumDate}
+            is24Hour={false}
+            dateFormat={"month day year"}
+            minuteInterval={5}
+            onChange={this.onChange}
+            timeZoneOffsetInSeconds={0} // This is necessary since DateTimePicker for some reason adds -1 hr timezone offset
+          />
+        ) : null}
+      </View>
     );
   }
 }

--- a/src/lib/DatePickerPlaceholder.js
+++ b/src/lib/DatePickerPlaceholder.js
@@ -2,7 +2,7 @@ import * as React from "react";
 import { Text } from "react-native";
 
 const DatePickerPlaceholder = props => (
-  <Text testID={`${props.tidRoot ?? ""}/Placeholder`} style={props.placeholderStyle}>
+  <Text testID={`Label`} style={props.placeholderStyle}>
     {props.placeholder}
   </Text>
 );

--- a/src/lib/DatePickerPlaceholder.js
+++ b/src/lib/DatePickerPlaceholder.js
@@ -2,7 +2,7 @@ import * as React from "react";
 import { Text } from "react-native";
 
 const DatePickerPlaceholder = props => (
-  <Text testID={`Label`} style={props.placeholderStyle}>
+  <Text testID="Label" style={props.placeholderStyle}>
     {props.placeholder}
   </Text>
 );

--- a/src/lib/DatePickerPlaceholder.js
+++ b/src/lib/DatePickerPlaceholder.js
@@ -1,10 +1,10 @@
 import * as React from "react";
-import { TText } from "@axsy-dev/testable";
+import { Text } from "react-native";
 
 const DatePickerPlaceholder = props => (
-  <TText tid="Placeholder" style={props.placeholderStyle}>
+  <Text testID={`${props.tidRoot ?? ""}/Placeholder`} style={props.placeholderStyle}>
     {props.placeholder}
-  </TText>
+  </Text>
 );
 
 export { DatePickerPlaceholder };

--- a/src/lib/Field.js
+++ b/src/lib/Field.js
@@ -7,16 +7,15 @@ let { View, StyleSheet, TouchableOpacity } = require("react-native");
 
 export class Field extends React.Component {
   render() {
-    const { tidRoot } = this.props;
     let fieldHelpText =
       this.props.helpTextComponent ||
       (this.props.helpText ? (
-        <HelpText tidRoot={tidRoot} text={this.props.helpText} color={this.props.helpTextColor} />
+        <HelpText text={this.props.helpText} color={this.props.helpTextColor} />
       ) : null);
 
     if (this.props.onPress) {
       return (
-        <TouchableOpacity onPress={this.props.onPress} testID={`${tidRoot ?? ""}/TapTarget`}>
+        <TouchableOpacity onPress={this.props.onPress} testID={`TapTarget`}>
           <View>
             {this.props.children}
             {fieldHelpText}
@@ -25,7 +24,7 @@ export class Field extends React.Component {
       );
     }
     return (
-      <View testID={`${tidRoot ?? ""}/Wrapper`}>
+      <View testID={`Wrapper`}>
         {this.props.children}
         {fieldHelpText}
       </View>

--- a/src/lib/Field.js
+++ b/src/lib/Field.js
@@ -3,30 +3,29 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { HelpText } from "./HelpText";
-let { View, StyleSheet } = require("react-native");
-
-import { TTouchableOpacity } from "@axsy-dev/testable";
+let { View, StyleSheet, TouchableOpacity } = require("react-native");
 
 export class Field extends React.Component {
   render() {
+    const { tidRoot } = this.props;
     let fieldHelpText =
       this.props.helpTextComponent ||
       (this.props.helpText ? (
-        <HelpText text={this.props.helpText} color={this.props.helpTextColor} />
+        <HelpText tidRoot={tidRoot} text={this.props.helpText} color={this.props.helpTextColor} />
       ) : null);
 
     if (this.props.onPress) {
       return (
-        <TTouchableOpacity onPress={this.props.onPress} tid={"OnPress"}>
+        <TouchableOpacity onPress={this.props.onPress} testID={`${tidRoot ?? ""}/TapTarget`}>
           <View>
             {this.props.children}
             {fieldHelpText}
           </View>
-        </TTouchableOpacity>
+        </TouchableOpacity>
       );
     }
     return (
-      <View>
+      <View testID={`${tidRoot ?? ""}/Wrapper`}>
         {this.props.children}
         {fieldHelpText}
       </View>

--- a/src/lib/Field.js
+++ b/src/lib/Field.js
@@ -3,7 +3,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { HelpText } from "./HelpText";
-let { View, StyleSheet, TouchableOpacity } = require("react-native");
+import { View, TouchableOpacity } from "react-native";
 
 export class Field extends React.Component {
   render() {
@@ -15,7 +15,7 @@ export class Field extends React.Component {
 
     if (this.props.onPress) {
       return (
-        <TouchableOpacity onPress={this.props.onPress} testID={`TapTarget`}>
+        <TouchableOpacity onPress={this.props.onPress} testID="TapTarget">
           <View>
             {this.props.children}
             {fieldHelpText}
@@ -24,7 +24,7 @@ export class Field extends React.Component {
       );
     }
     return (
-      <View testID={`Wrapper`}>
+      <View testID="Wrapper">
         {this.props.children}
         {fieldHelpText}
       </View>

--- a/src/lib/HelpText.js
+++ b/src/lib/HelpText.js
@@ -6,13 +6,13 @@ import PropTypes from "prop-types";
 import { View, StyleSheet, Text } from "react-native";
 export class HelpText extends React.Component {
   render() {
-    const { text, color, tidRoot } = this.props;
+    const { text, color } = this.props;
     if (!text) return null;
 
     const textColor = !!color ? { color } : {};
     return (
       <View style={formStyles.helpTextContainer}>
-        <Text testID={`${tidRoot ?? ""}/HelpText`} style={[formStyles.helpText, textColor]}>
+        <Text testID={`HelpText`} style={[formStyles.helpText, textColor]}>
           {text}
         </Text>
       </View>

--- a/src/lib/HelpText.js
+++ b/src/lib/HelpText.js
@@ -3,22 +3,21 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-import { View, StyleSheet } from "react-native";
+import { View, StyleSheet, Text } from "react-native";
 
 import { TText } from "@axsy-dev/testable";
 
 export class HelpText extends React.Component {
   render() {
-    const { text, color } = this.props;
+    const { text, color, tidRoot } = this.props;
     if (!text) return null;
 
     const textColor = !!color ? { color } : {};
-
     return (
       <View style={formStyles.helpTextContainer}>
-        <TText tid="HelpText" style={[formStyles.helpText, textColor]}>
+        <Text testID={`${tidRoot ?? ""}/HelpText`} style={[formStyles.helpText, textColor]}>
           {text}
-        </TText>
+        </Text>
       </View>
     );
   }

--- a/src/lib/HelpText.js
+++ b/src/lib/HelpText.js
@@ -4,9 +4,6 @@ import React from "react";
 import PropTypes from "prop-types";
 
 import { View, StyleSheet, Text } from "react-native";
-
-import { TText } from "@axsy-dev/testable";
-
 export class HelpText extends React.Component {
   render() {
     const { text, color, tidRoot } = this.props;

--- a/src/lib/HelpText.js
+++ b/src/lib/HelpText.js
@@ -12,7 +12,7 @@ export class HelpText extends React.Component {
     const textColor = !!color ? { color } : {};
     return (
       <View style={formStyles.helpTextContainer}>
-        <Text testID={`HelpText`} style={[formStyles.helpText, textColor]}>
+        <Text testID="HelpText" style={[formStyles.helpText, textColor]}>
           {text}
         </Text>
       </View>

--- a/src/lib/InputComponent.tsx
+++ b/src/lib/InputComponent.tsx
@@ -41,7 +41,6 @@ type Props = TextInputProps & {
     event: NativeSyntheticEvent<TextInputFocusEventData>,
     handle: ReturnType<typeof findNodeHandle>
   ) => void;
-  tidRoot: string;
 };
 
 type State = {
@@ -271,8 +270,6 @@ export class InputComponent extends React.Component<Props, State> {
   };
 
   render() {
-    const { tidRoot } = this.props;
-
     return (
       <Field {...this.props}>
         <View
@@ -282,7 +279,7 @@ export class InputComponent extends React.Component<Props, State> {
           {this.props.iconLeft ? this.props.iconLeft : null}
           {this.props.label ? (
             <Text
-              testID={`${tidRoot ?? ""}/Label`}
+              testID={`Label`}
               style={this.props.labelStyle}
               onLayout={this.handleLabelLayoutChange}
               onPress={this.handleFieldPress}
@@ -294,7 +291,7 @@ export class InputComponent extends React.Component<Props, State> {
           <TextInput
             {...this.props}
             ref={this.saveRef}
-            testID={`${tidRoot ?? ""}/Input`}
+            testID={`Input`}
             keyboardType={this.props.keyboardType}
             style={this.props.inputStyle}
             onChange={this.handleChangeFromInput}

--- a/src/lib/InputComponent.tsx
+++ b/src/lib/InputComponent.tsx
@@ -279,7 +279,7 @@ export class InputComponent extends React.Component<Props, State> {
           {this.props.iconLeft ? this.props.iconLeft : null}
           {this.props.label ? (
             <Text
-              testID={`Label`}
+              testID="Label"
               style={this.props.labelStyle}
               onLayout={this.handleLabelLayoutChange}
               onPress={this.handleFieldPress}
@@ -291,7 +291,7 @@ export class InputComponent extends React.Component<Props, State> {
           <TextInput
             {...this.props}
             ref={this.saveRef}
-            testID={`Input`}
+            testID="Input"
             keyboardType={this.props.keyboardType}
             style={this.props.inputStyle}
             onChange={this.handleChangeFromInput}

--- a/src/lib/LinkComponent.js
+++ b/src/lib/LinkComponent.js
@@ -3,9 +3,6 @@
 import React from "react";
 let { View, StyleSheet, Text, ViewPropTypes } = require("react-native");
 import { Field } from "./Field";
-
-import { TestPathContainer, TText } from "@axsy-dev/testable";
-
 export class LinkComponent extends React.Component {
   constructor(props) {
     super(props);
@@ -18,6 +15,7 @@ export class LinkComponent extends React.Component {
   }
 
   render() {
+    const { tidRoot } = this.props;
     return (
       <Field {...this.props}>
         <View
@@ -25,9 +23,9 @@ export class LinkComponent extends React.Component {
           onLayout={this.handleLayoutChange.bind(this)}
         >
           {this.props.iconLeft ? this.props.iconLeft : null}
-          <TText tid="Label" style={this.props.labelStyle}>
+          <Text testID={`${tidRoot ?? ""}/Label`} style={this.props.labelStyle}>
             {this.props.label}
-          </TText>
+          </Text>
 
           {this.props.iconRight ? this.props.iconRight : null}
         </View>

--- a/src/lib/LinkComponent.js
+++ b/src/lib/LinkComponent.js
@@ -15,7 +15,6 @@ export class LinkComponent extends React.Component {
   }
 
   render() {
-    
     return (
       <Field {...this.props}>
         <View

--- a/src/lib/LinkComponent.js
+++ b/src/lib/LinkComponent.js
@@ -15,7 +15,7 @@ export class LinkComponent extends React.Component {
   }
 
   render() {
-    const { tidRoot } = this.props;
+    
     return (
       <Field {...this.props}>
         <View
@@ -23,7 +23,7 @@ export class LinkComponent extends React.Component {
           onLayout={this.handleLayoutChange.bind(this)}
         >
           {this.props.iconLeft ? this.props.iconLeft : null}
-          <Text testID={`${tidRoot ?? ""}/Label`} style={this.props.labelStyle}>
+          <Text testID={`Label`} style={this.props.labelStyle}>
             {this.props.label}
           </Text>
 

--- a/src/lib/LinkComponent.js
+++ b/src/lib/LinkComponent.js
@@ -1,7 +1,7 @@
 "use strict";
 
 import React from "react";
-let { View, StyleSheet, Text, ViewPropTypes } = require("react-native");
+import { View, Text, ViewPropTypes } from "react-native";
 import { Field } from "./Field";
 export class LinkComponent extends React.Component {
   constructor(props) {
@@ -23,7 +23,7 @@ export class LinkComponent extends React.Component {
           onLayout={this.handleLayoutChange.bind(this)}
         >
           {this.props.iconLeft ? this.props.iconLeft : null}
-          <Text testID={`Label`} style={this.props.labelStyle}>
+          <Text testID="Label" style={this.props.labelStyle}>
             {this.props.label}
           </Text>
 

--- a/src/lib/PickerComponent.android.js
+++ b/src/lib/PickerComponent.android.js
@@ -1,15 +1,12 @@
 "use strict";
 
 import React from "react";
-import ReactNative, { View, TouchableOpacity } from "react-native";
+import ReactNative, { View, TouchableOpacity, Text } from "react-native";
 import { Field } from "../lib/Field";
-
 import {
-  TestPathSegment,
-  TText,
-  TPicker,
-  TPickerItem
-} from "@axsy-dev/testable";
+    Picker
+} from "@react-native-picker/picker";
+
 import _ from "lodash";
 
 export class PickerComponent extends React.Component {
@@ -40,6 +37,7 @@ export class PickerComponent extends React.Component {
   };
 
   render() {
+    const { tidRoot } = this.props;
     // prefer state value if set
     const value = this.state.value ? this.state.value : this.props.value;
 
@@ -49,27 +47,26 @@ export class PickerComponent extends React.Component {
     );
 
     return (
-      <TestPathSegment name={`Field[${this.props.fieldRef}]` || "Picker"}>
         <View>
           <Field {...this.props} ref="inputBox" onPress={this.props.onPress}>
             <View
               style={this.props.containerStyle}
               onLayout={this.handleLayoutChange}
             >
-              <TText tid="Label" style={this.props.labelStyle}>
+              <Text testID={`${tidRoot ?? ""}/Label`} style={this.props.labelStyle}>
                 {this.props.label}
-              </TText>
+              </Text>
               <View style={this.props.pickerWrapperStyle}>
-                <TPicker
-                  tid="Picker"
+                <Picker
+                  testID={`${tidRoot ?? ""}/Picker`}
                   {...this.props.pickerProps}
                   selectedValue={selectedOption ? selectedOption.value : null}
                   onValueChange={this.handleValueChange}
                 >
                   {this.props.options.map(
                     ({ value, label }, idx) => (
-                      <TPickerItem
-                        tid={`PickerItem[${idx}]`}
+                      <Picker.Item
+                        testID={`${tidRoot ?? ""}/PickerItem[${idx}]`}
                         key={value}
                         value={value}
                         label={label}
@@ -77,13 +74,12 @@ export class PickerComponent extends React.Component {
                     ),
                     this
                   )}
-                </TPicker>
+                </Picker>
                 <TouchableOpacity activeOpacity={0} style={pickerCoverStyle} />
               </View>
             </View>
           </Field>
         </View>
-      </TestPathSegment>
     );
   }
 }

--- a/src/lib/PickerComponent.android.js
+++ b/src/lib/PickerComponent.android.js
@@ -37,7 +37,7 @@ export class PickerComponent extends React.Component {
   };
 
   render() {
-    const { tidRoot } = this.props;
+    
     // prefer state value if set
     const value = this.state.value ? this.state.value : this.props.value;
 
@@ -53,12 +53,12 @@ export class PickerComponent extends React.Component {
               style={this.props.containerStyle}
               onLayout={this.handleLayoutChange}
             >
-              <Text testID={`${tidRoot ?? ""}/Label`} style={this.props.labelStyle}>
+              <Text testID={`Label`} style={this.props.labelStyle}>
                 {this.props.label}
               </Text>
               <View style={this.props.pickerWrapperStyle}>
                 <Picker
-                  testID={`${tidRoot ?? ""}/Picker`}
+                  testID={`Picker`}
                   {...this.props.pickerProps}
                   selectedValue={selectedOption ? selectedOption.value : null}
                   onValueChange={this.handleValueChange}
@@ -66,7 +66,7 @@ export class PickerComponent extends React.Component {
                   {this.props.options.map(
                     ({ value, label }, idx) => (
                       <Picker.Item
-                        testID={`${tidRoot ?? ""}/PickerItem[${idx}]`}
+                        testID={`PickerItem/${idx}`}
                         key={value}
                         value={value}
                         label={label}

--- a/src/lib/PickerComponent.android.js
+++ b/src/lib/PickerComponent.android.js
@@ -53,12 +53,12 @@ export class PickerComponent extends React.Component {
               style={this.props.containerStyle}
               onLayout={this.handleLayoutChange}
             >
-              <Text testID={`Label`} style={this.props.labelStyle}>
+              <Text testID="Label" style={this.props.labelStyle}>
                 {this.props.label}
               </Text>
               <View style={this.props.pickerWrapperStyle}>
                 <Picker
-                  testID={`Picker`}
+                  testID="Picker"
                   {...this.props.pickerProps}
                   selectedValue={selectedOption ? selectedOption.value : null}
                   onValueChange={this.handleValueChange}

--- a/src/lib/PickerComponent.android.js
+++ b/src/lib/PickerComponent.android.js
@@ -1,11 +1,9 @@
 "use strict";
 
 import React from "react";
-import ReactNative, { View, TouchableOpacity, Text } from "react-native";
+import { View, TouchableOpacity, Text } from "react-native";
 import { Field } from "../lib/Field";
-import {
-    Picker
-} from "@react-native-picker/picker";
+import { Picker } from "@react-native-picker/picker";
 
 import _ from "lodash";
 
@@ -37,7 +35,6 @@ export class PickerComponent extends React.Component {
   };
 
   render() {
-    
     // prefer state value if set
     const value = this.state.value ? this.state.value : this.props.value;
 
@@ -47,39 +44,39 @@ export class PickerComponent extends React.Component {
     );
 
     return (
-        <View>
-          <Field {...this.props} ref="inputBox" onPress={this.props.onPress}>
-            <View
-              style={this.props.containerStyle}
-              onLayout={this.handleLayoutChange}
-            >
-              <Text testID="Label" style={this.props.labelStyle}>
-                {this.props.label}
-              </Text>
-              <View style={this.props.pickerWrapperStyle}>
-                <Picker
-                  testID="Picker"
-                  {...this.props.pickerProps}
-                  selectedValue={selectedOption ? selectedOption.value : null}
-                  onValueChange={this.handleValueChange}
-                >
-                  {this.props.options.map(
-                    ({ value, label }, idx) => (
-                      <Picker.Item
-                        testID={`PickerItem/${idx}`}
-                        key={value}
-                        value={value}
-                        label={label}
-                      />
-                    ),
-                    this
-                  )}
-                </Picker>
-                <TouchableOpacity activeOpacity={0} style={pickerCoverStyle} />
-              </View>
+      <View>
+        <Field {...this.props} ref="inputBox" onPress={this.props.onPress}>
+          <View
+            style={this.props.containerStyle}
+            onLayout={this.handleLayoutChange}
+          >
+            <Text testID="Label" style={this.props.labelStyle}>
+              {this.props.label}
+            </Text>
+            <View style={this.props.pickerWrapperStyle}>
+              <Picker
+                testID="Picker"
+                {...this.props.pickerProps}
+                selectedValue={selectedOption ? selectedOption.value : null}
+                onValueChange={this.handleValueChange}
+              >
+                {this.props.options.map(
+                  ({ value, label }, idx) => (
+                    <Picker.Item
+                      testID={`PickerItem/${idx}`}
+                      key={value}
+                      value={value}
+                      label={label}
+                    />
+                  ),
+                  this
+                )}
+              </Picker>
+              <TouchableOpacity activeOpacity={0} style={pickerCoverStyle} />
             </View>
-          </Field>
-        </View>
+          </View>
+        </Field>
+      </View>
     );
   }
 }

--- a/src/lib/PickerComponent.ios.js
+++ b/src/lib/PickerComponent.ios.js
@@ -3,15 +3,11 @@
 import React from "react";
 import _ from "lodash";
 import PropTypes from "prop-types";
-import { View } from "react-native";
+import { View, Text } from "react-native";
 import { Field } from "../lib/Field";
-
 import {
-  TestPathSegment,
-  TText,
-  TPicker,
-  TPickerItem
-} from "@axsy-dev/testable";
+    Picker
+} from "@react-native-picker/picker";
 
 class RenderedSelector extends React.Component {
   constructor(props) {
@@ -29,9 +25,10 @@ class RenderedSelector extends React.Component {
   }
 
   render() {
+    const { tidRoot } = this.props;
     let picker = (
-      <TPicker
-        tid="Picker"
+      <Picker
+        testID={`${tidRoot ?? ""}/Picker`}
         {...this.props.pickerProps}
         selectedValue={this.state.value}
         onValueChange={this.handleValueChange.bind(this)}
@@ -39,8 +36,8 @@ class RenderedSelector extends React.Component {
       >
         {this.props.options.map(
           ({ value, label }, idx) => (
-            <TPickerItem
-              tid={`PickerItem[${idx}]`}
+            <Picker.Item
+                testID={`${tidRoot ?? ""}/PickerItem[${idx}]`}
               key={value}
               value={value}
               label={label}
@@ -48,7 +45,7 @@ class RenderedSelector extends React.Component {
           ),
           this
         )}
-      </TPicker>
+      </Picker>
     );
 
     return React.cloneElement(
@@ -133,6 +130,7 @@ export class PickerComponent extends React.Component {
   }
 
   render() {
+    const { tidRoot } = this.props;
     let iconLeft = this.props.iconLeft,
       iconRight = this.props.iconRight;
 
@@ -149,7 +147,6 @@ export class PickerComponent extends React.Component {
     );
 
     return (
-      <TestPathSegment name={`Field[${this.props.fieldRef}]` || "Picker"}>
         <View>
           <Field
             {...this.props}
@@ -161,20 +158,19 @@ export class PickerComponent extends React.Component {
               onLayout={this.handleLayoutChange.bind(this)}
             >
               {iconLeft ? iconLeft : null}
-              <TText tid="Label" style={this.props.labelStyle}>
+              <Text testID={`${tidRoot ?? ""}/Label`} style={this.props.labelStyle}>
                 {this.props.label}
-              </TText>
+              </Text>
               <View style={this.props.valueContainerStyle}>
-                <TText tid="Value" style={this.props.valueStyle}>
+                <Text testID={`${tidRoot ?? ""}/Value`} style={this.props.valueStyle}>
                   {selectedOption ? selectedOption.label : ""}
-                </TText>
+                </Text>
               </View>
               {this.props.iconRight ? this.props.iconRight : null}
             </View>
           </Field>
           {this.state.isPickerVisible ? this._renderContent() : null}
         </View>
-      </TestPathSegment>
     );
   }
 }

--- a/src/lib/PickerComponent.ios.js
+++ b/src/lib/PickerComponent.ios.js
@@ -25,10 +25,10 @@ class RenderedSelector extends React.Component {
   }
 
   render() {
-    const { tidRoot } = this.props;
+    
     let picker = (
       <Picker
-        testID={`${tidRoot ?? ""}/Picker`}
+        testID={`Picker`}
         {...this.props.pickerProps}
         selectedValue={this.state.value}
         onValueChange={this.handleValueChange.bind(this)}
@@ -37,7 +37,7 @@ class RenderedSelector extends React.Component {
         {this.props.options.map(
           ({ value, label }, idx) => (
             <Picker.Item
-                testID={`${tidRoot ?? ""}/PickerItem[${idx}]`}
+                testID={`PickerItem/${idx}`}
               key={value}
               value={value}
               label={label}
@@ -130,7 +130,7 @@ export class PickerComponent extends React.Component {
   }
 
   render() {
-    const { tidRoot } = this.props;
+    
     let iconLeft = this.props.iconLeft,
       iconRight = this.props.iconRight;
 
@@ -158,11 +158,11 @@ export class PickerComponent extends React.Component {
               onLayout={this.handleLayoutChange.bind(this)}
             >
               {iconLeft ? iconLeft : null}
-              <Text testID={`${tidRoot ?? ""}/Label`} style={this.props.labelStyle}>
+              <Text testID={`Label`} style={this.props.labelStyle}>
                 {this.props.label}
               </Text>
               <View style={this.props.valueContainerStyle}>
-                <Text testID={`${tidRoot ?? ""}/Value`} style={this.props.valueStyle}>
+                <Text testID={`Value`} style={this.props.valueStyle}>
                   {selectedOption ? selectedOption.label : ""}
                 </Text>
               </View>

--- a/src/lib/PickerComponent.ios.js
+++ b/src/lib/PickerComponent.ios.js
@@ -28,7 +28,7 @@ class RenderedSelector extends React.Component {
     
     let picker = (
       <Picker
-        testID={`Picker`}
+        testID="Picker"
         {...this.props.pickerProps}
         selectedValue={this.state.value}
         onValueChange={this.handleValueChange.bind(this)}
@@ -158,11 +158,11 @@ export class PickerComponent extends React.Component {
               onLayout={this.handleLayoutChange.bind(this)}
             >
               {iconLeft ? iconLeft : null}
-              <Text testID={`Label`} style={this.props.labelStyle}>
+              <Text testID="Label" style={this.props.labelStyle}>
                 {this.props.label}
               </Text>
               <View style={this.props.valueContainerStyle}>
-                <Text testID={`Value`} style={this.props.valueStyle}>
+                <Text testID="Value" style={this.props.valueStyle}>
                   {selectedOption ? selectedOption.label : ""}
                 </Text>
               </View>

--- a/src/lib/PickerComponent.ios.js
+++ b/src/lib/PickerComponent.ios.js
@@ -5,9 +5,7 @@ import _ from "lodash";
 import PropTypes from "prop-types";
 import { View, Text } from "react-native";
 import { Field } from "../lib/Field";
-import {
-    Picker
-} from "@react-native-picker/picker";
+import { Picker } from "@react-native-picker/picker";
 
 class RenderedSelector extends React.Component {
   constructor(props) {
@@ -25,7 +23,6 @@ class RenderedSelector extends React.Component {
   }
 
   render() {
-    
     let picker = (
       <Picker
         testID="Picker"
@@ -37,7 +34,7 @@ class RenderedSelector extends React.Component {
         {this.props.options.map(
           ({ value, label }, idx) => (
             <Picker.Item
-                testID={`PickerItem/${idx}`}
+              testID={`PickerItem/${idx}`}
               key={value}
               value={value}
               label={label}
@@ -130,7 +127,6 @@ export class PickerComponent extends React.Component {
   }
 
   render() {
-    
     let iconLeft = this.props.iconLeft,
       iconRight = this.props.iconRight;
 
@@ -147,30 +143,30 @@ export class PickerComponent extends React.Component {
     );
 
     return (
-        <View>
-          <Field
-            {...this.props}
-            ref="inputBox"
-            onPress={this._togglePicker.bind(this)}
+      <View>
+        <Field
+          {...this.props}
+          ref="inputBox"
+          onPress={this._togglePicker.bind(this)}
+        >
+          <View
+            style={this.props.containerStyle}
+            onLayout={this.handleLayoutChange.bind(this)}
           >
-            <View
-              style={this.props.containerStyle}
-              onLayout={this.handleLayoutChange.bind(this)}
-            >
-              {iconLeft ? iconLeft : null}
-              <Text testID="Label" style={this.props.labelStyle}>
-                {this.props.label}
+            {iconLeft ? iconLeft : null}
+            <Text testID="Label" style={this.props.labelStyle}>
+              {this.props.label}
+            </Text>
+            <View style={this.props.valueContainerStyle}>
+              <Text testID="Value" style={this.props.valueStyle}>
+                {selectedOption ? selectedOption.label : ""}
               </Text>
-              <View style={this.props.valueContainerStyle}>
-                <Text testID="Value" style={this.props.valueStyle}>
-                  {selectedOption ? selectedOption.label : ""}
-                </Text>
-              </View>
-              {this.props.iconRight ? this.props.iconRight : null}
             </View>
-          </Field>
-          {this.state.isPickerVisible ? this._renderContent() : null}
-        </View>
+            {this.props.iconRight ? this.props.iconRight : null}
+          </View>
+        </Field>
+        {this.state.isPickerVisible ? this._renderContent() : null}
+      </View>
     );
   }
 }

--- a/src/lib/PickerComponent.windows.js
+++ b/src/lib/PickerComponent.windows.js
@@ -66,7 +66,7 @@ export class PickerComponent extends React.Component {
   };
 
   render() {
-    const { tidRoot } = this.props;
+    
     let iconLeft = this.props.iconLeft,
       iconRight = this.props.iconRight;
 
@@ -90,18 +90,18 @@ export class PickerComponent extends React.Component {
               onLayout={this.handleLayoutChange}
             >
               {iconLeft ? iconLeft : null}
-              <Text testID={`${tidRoot ?? ""}/Label`} style={this.props.labelStyle}>
+              <Text testID={`Label`} style={this.props.labelStyle}>
                 {this.props.label}
               </Text>
               <Picker
-                testID={`${tidRoot ?? ""}/Picker`}
+                testID={`Picker`}
                 {...this.props.pickerProps}
                 selectedValue={selectedOption ? selectedOption.value : null}
                 onValueChange={this.handleValueChange}
               >
                 {this.props.options.map(({ value, label }, idx) => (
                   <Picker.Item
-                    testID={`${tidRoot ?? ""}/PickerItem[${idx}]`}
+                    testID={`PickerItem/${idx}`}
                     key={value}
                     value={value}
                     label={label}

--- a/src/lib/PickerComponent.windows.js
+++ b/src/lib/PickerComponent.windows.js
@@ -4,9 +4,7 @@ import React from "react";
 import { View, findNodeHandle, Text } from "react-native";
 import PropTypes from "prop-types";
 import { Field } from "../lib/Field";
-import {
-    Picker
-} from "@react-native-picker/picker";
+import { Picker } from "@react-native-picker/picker";
 import _ from "lodash";
 
 export class PickerComponent extends React.Component {
@@ -66,7 +64,6 @@ export class PickerComponent extends React.Component {
   };
 
   render() {
-    
     let iconLeft = this.props.iconLeft,
       iconRight = this.props.iconRight;
 
@@ -83,34 +80,34 @@ export class PickerComponent extends React.Component {
     );
 
     return (
-        <View>
-          <Field {...this.props} ref="inputBox" onPress={this.props.onPress}>
-            <View
-              style={this.props.containerStyle}
-              onLayout={this.handleLayoutChange}
+      <View>
+        <Field {...this.props} ref="inputBox" onPress={this.props.onPress}>
+          <View
+            style={this.props.containerStyle}
+            onLayout={this.handleLayoutChange}
+          >
+            {iconLeft ? iconLeft : null}
+            <Text testID="Label" style={this.props.labelStyle}>
+              {this.props.label}
+            </Text>
+            <Picker
+              testID="Picker"
+              {...this.props.pickerProps}
+              selectedValue={selectedOption ? selectedOption.value : null}
+              onValueChange={this.handleValueChange}
             >
-              {iconLeft ? iconLeft : null}
-              <Text testID="Label" style={this.props.labelStyle}>
-                {this.props.label}
-              </Text>
-              <Picker
-                testID="Picker"
-                {...this.props.pickerProps}
-                selectedValue={selectedOption ? selectedOption.value : null}
-                onValueChange={this.handleValueChange}
-              >
-                {this.props.options.map(({ value, label }, idx) => (
-                  <Picker.Item
-                    testID={`PickerItem/${idx}`}
-                    key={value}
-                    value={value}
-                    label={label}
-                  />
-                ))}
-              </Picker>
-            </View>
-          </Field>
-        </View>
+              {this.props.options.map(({ value, label }, idx) => (
+                <Picker.Item
+                  testID={`PickerItem/${idx}`}
+                  key={value}
+                  value={value}
+                  label={label}
+                />
+              ))}
+            </Picker>
+          </View>
+        </Field>
+      </View>
     );
   }
 }

--- a/src/lib/PickerComponent.windows.js
+++ b/src/lib/PickerComponent.windows.js
@@ -1,7 +1,7 @@
 "use strict";
 
 import React from "react";
-import { View, findNodeHandle } from "react-native";
+import { View, findNodeHandle, Text } from "react-native";
 import PropTypes from "prop-types";
 import { Field } from "../lib/Field";
 import {

--- a/src/lib/PickerComponent.windows.js
+++ b/src/lib/PickerComponent.windows.js
@@ -90,11 +90,11 @@ export class PickerComponent extends React.Component {
               onLayout={this.handleLayoutChange}
             >
               {iconLeft ? iconLeft : null}
-              <Text testID={`Label`} style={this.props.labelStyle}>
+              <Text testID="Label" style={this.props.labelStyle}>
                 {this.props.label}
               </Text>
               <Picker
-                testID={`Picker`}
+                testID="Picker"
                 {...this.props.pickerProps}
                 selectedValue={selectedOption ? selectedOption.value : null}
                 onValueChange={this.handleValueChange}

--- a/src/lib/PickerComponent.windows.js
+++ b/src/lib/PickerComponent.windows.js
@@ -4,14 +4,9 @@ import React from "react";
 import { View, findNodeHandle } from "react-native";
 import PropTypes from "prop-types";
 import { Field } from "../lib/Field";
-
 import {
-  TestPathContainer,
-  TText,
-  TPicker,
-  TPickerItem,
-  TestPathSegment
-} from "@axsy-dev/testable";
+    Picker
+} from "@react-native-picker/picker";
 import _ from "lodash";
 
 export class PickerComponent extends React.Component {
@@ -71,6 +66,7 @@ export class PickerComponent extends React.Component {
   };
 
   render() {
+    const { tidRoot } = this.props;
     let iconLeft = this.props.iconLeft,
       iconRight = this.props.iconRight;
 
@@ -87,7 +83,6 @@ export class PickerComponent extends React.Component {
     );
 
     return (
-      <TestPathSegment name={`Field[${this.props.fieldRef}]` || "Picker"}>
         <View>
           <Field {...this.props} ref="inputBox" onPress={this.props.onPress}>
             <View
@@ -95,28 +90,27 @@ export class PickerComponent extends React.Component {
               onLayout={this.handleLayoutChange}
             >
               {iconLeft ? iconLeft : null}
-              <TText tid="Label" style={this.props.labelStyle}>
+              <Text testID={`${tidRoot ?? ""}/Label`} style={this.props.labelStyle}>
                 {this.props.label}
-              </TText>
-              <TPicker
-                tid="Picker"
+              </Text>
+              <Picker
+                testID={`${tidRoot ?? ""}/Picker`}
                 {...this.props.pickerProps}
                 selectedValue={selectedOption ? selectedOption.value : null}
                 onValueChange={this.handleValueChange}
               >
                 {this.props.options.map(({ value, label }, idx) => (
-                  <TPickerItem
-                    tid={`PickerItem[${idx}]`}
+                  <Picker.Item
+                    testID={`${tidRoot ?? ""}/PickerItem[${idx}]`}
                     key={value}
                     value={value}
                     label={label}
                   />
                 ))}
-              </TPicker>
+              </Picker>
             </View>
           </Field>
         </View>
-      </TestPathSegment>
     );
   }
 }

--- a/src/lib/SwitchComponent.js
+++ b/src/lib/SwitchComponent.js
@@ -1,11 +1,9 @@
 "use strict";
 
 import React from "react";
-let { View, StyleSheet, Text, Switch, ViewPropTypes } = require("react-native");
+let { View, Text, Switch, ViewPropTypes } = require("react-native");
 
 import { Field } from "./Field";
-
-import { TestPathSegment } from "@axsy-dev/testable";
 
 export class SwitchComponent extends React.Component {
   constructor(props) {
@@ -36,21 +34,19 @@ export class SwitchComponent extends React.Component {
 
   render() {
     return (
-      <TestPathSegment name={`Field[${this.props.fieldRef}]` || "Switch"}>
-        <Field {...this.props}>
-          <View
-            style={this.props.containerStyle}
-            onLayout={this.handleLayoutChange.bind(this)}
-          >
-            <Text style={this.props.labelStyle}>{this.props.label}</Text>
-            <Switch
-              onValueChange={this.handleValueChange.bind(this)}
-              style={this.props.switchStyle}
-              value={this.state.value}
-            />
-          </View>
-        </Field>
-      </TestPathSegment>
+      <Field {...this.props}>
+        <View
+          style={this.props.containerStyle}
+          onLayout={this.handleLayoutChange.bind(this)}
+        >
+          <Text style={this.props.labelStyle}>{this.props.label}</Text>
+          <Switch
+            onValueChange={this.handleValueChange.bind(this)}
+            style={this.props.switchStyle}
+            value={this.state.value}
+          />
+        </View>
+      </Field>
     );
   }
 }

--- a/src/lib/SwitchComponent.js
+++ b/src/lib/SwitchComponent.js
@@ -1,7 +1,7 @@
 "use strict";
 
 import React from "react";
-let { View, Text, Switch, ViewPropTypes } = require("react-native");
+import { View, Text, Switch, ViewPropTypes } from "react-native";
 
 import { Field } from "./Field";
 

--- a/src/lib/TimePickerComponent.android.js
+++ b/src/lib/TimePickerComponent.android.js
@@ -8,8 +8,6 @@ import DateTimePicker from "@react-native-community/datetimepicker";
 
 import { Field } from "./Field";
 
-import { TestPathSegment, TText } from "@axsy-dev/testable";
-
 export class TimePickerComponent extends React.Component {
   constructor(props) {
     super(props);
@@ -64,46 +62,45 @@ export class TimePickerComponent extends React.Component {
   }
 
   render() {
+    const { tidRoot } = this.props;
     const timeValue = this.state.date || new Date(0, 0, 0);
 
     let placeholderComponent = this.props.placeholderComponent ? (
       this.props.placeholderComponent
     ) : (
-      <TText tid="Placeholder" style={this.props.placeholderStyle}>
+      <Text testID={`${tidRoot ?? ""}/Placeholder`} style={this.props.placeholderStyle}>
         {this.props.placeholder}
-      </TText>
+      </Text>
     );
     return (
-      <TestPathSegment name={`Field[${this.props.fieldRef}]` || "DatePicker"}>
-        <View>
-          <Field
-            {...this.props}
-            ref="inputBox"
-            onPress={this._togglePicker.bind(this)}
+      <View>
+        <Field
+          {...this.props}
+          ref="inputBox"
+          onPress={this._togglePicker.bind(this)}
+        >
+          <View
+            style={this.props.containerStyle}
+            onLayout={this.handleLayoutChange.bind(this)}
           >
-            <View
-              style={this.props.containerStyle}
-              onLayout={this.handleLayoutChange.bind(this)}
-            >
-              {placeholderComponent}
-              <View style={this.props.valueContainerStyle}>
-                <TText tid="Value" style={[this.props.valueStyle]}>
-                  {this.props.dateTimeFormat(this.state.date)}
-                </TText>
-              </View>
-              {this.props.iconRight ? this.props.iconRight : null}
+            {placeholderComponent}
+            <View style={this.props.valueContainerStyle}>
+              <Text testID={`${tidRoot ?? ""}/Value`} style={[this.props.valueStyle]}>
+                {this.props.dateTimeFormat(this.state.date)}
+              </Text>
             </View>
-          </Field>
-          {this.state.isTimePickerVisible ? (
-            <DateTimePicker
-              {...this.props}
-              mode="time"
-              value={timeValue}
-              onChange={this.handleValueChange.bind(this)}
-            />
-          ) : null}
-        </View>
-      </TestPathSegment>
+            {this.props.iconRight ? this.props.iconRight : null}
+          </View>
+        </Field>
+        {this.state.isTimePickerVisible ? (
+          <DateTimePicker
+            {...this.props}
+            mode="time"
+            value={timeValue}
+            onChange={this.handleValueChange.bind(this)}
+          />
+        ) : null}
+      </View>
     );
   }
 }

--- a/src/lib/TimePickerComponent.android.js
+++ b/src/lib/TimePickerComponent.android.js
@@ -62,13 +62,12 @@ export class TimePickerComponent extends React.Component {
   }
 
   render() {
-    const { tidRoot } = this.props;
     const timeValue = this.state.date || new Date(0, 0, 0);
 
     let placeholderComponent = this.props.placeholderComponent ? (
       this.props.placeholderComponent
     ) : (
-      <Text testID={`${tidRoot ?? ""}/Placeholder`} style={this.props.placeholderStyle}>
+      <Text testID={`Label`} style={this.props.placeholderStyle}>
         {this.props.placeholder}
       </Text>
     );
@@ -85,7 +84,7 @@ export class TimePickerComponent extends React.Component {
           >
             {placeholderComponent}
             <View style={this.props.valueContainerStyle}>
-              <Text testID={`${tidRoot ?? ""}/Value`} style={[this.props.valueStyle]}>
+              <Text testID={`Value`} style={[this.props.valueStyle]}>
                 {this.props.dateTimeFormat(this.state.date)}
               </Text>
             </View>

--- a/src/lib/TimePickerComponent.android.js
+++ b/src/lib/TimePickerComponent.android.js
@@ -2,7 +2,7 @@
 
 import React from "react";
 import PropTypes from "prop-types";
-import { View } from "react-native";
+import { View, Text } from "react-native";
 
 import DateTimePicker from "@react-native-community/datetimepicker";
 
@@ -67,7 +67,7 @@ export class TimePickerComponent extends React.Component {
     let placeholderComponent = this.props.placeholderComponent ? (
       this.props.placeholderComponent
     ) : (
-      <Text testID={`Label`} style={this.props.placeholderStyle}>
+      <Text testID="Label" style={this.props.placeholderStyle}>
         {this.props.placeholder}
       </Text>
     );

--- a/src/lib/TouchableContainer.js
+++ b/src/lib/TouchableContainer.js
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { TTouchableOpacity } from "@axsy-dev/testable";
+import { TouchableOpacity } from "react-native";
 
 const style = {
   flex: 1,
@@ -11,9 +11,9 @@ const style = {
 };
 
 const TouchableContainer = props => (
-  <TTouchableOpacity tid={props.tid} style={style} onPress={props.onPress}>
+  <TouchableOpacity testID={props.tid} style={style} onPress={props.onPress}>
     {props.children}
-  </TTouchableOpacity>
+  </TouchableOpacity>
 );
 
 export { TouchableContainer };


### PR DESCRIPTION
- Replaces any components from the testable library with their underlying components
- Replaces TestPathSegment with a `tidRoot` which is defined in Form.js to the parent elements testID if `hasTestableWrappers` is set or `Element[index]` if's not.
- Fixes some typescript issues in `InputComponent` - I've tried to be as careful as possible to not change the behaviour of the field

I've tested this using flows which contain all the elements we support on Android and iOS (I'll keep this a draft until I test on Windows too), but I'm aware that doesn't cover all of the components in RNFG (the Switch and Link components for example) so am keen to get any suggestions for other places to test