### PR TITLE
Add support fields in flow sections

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "test:watch": "jest --watchAll",
     "format": "prettier --write --loglevel=silent"
   },
-  "version": "0.9.37",
+  "version": "0.9.38",
   "devDependencies": {
     "@tsconfig/react-native": "^1.0.4",
     "@types/react": "^17.0.39",

--- a/src/Form.js
+++ b/src/Form.js
@@ -54,17 +54,12 @@ export class Form extends Component {
 
   addProps(element, isTestable, key) {
     const target = isTestable ? element.props.children : element;
-    const fieldName =
-      target.props.fieldRef ??
-      target.props.fieldKey ??
-      target.props?.field?.name ??
-      "unknown-field-name";
     return React.cloneElement(target, {
       key,
       fieldRef: target.ref,
       ref: target.ref,
       onFocus: this.handleFieldFocused.bind(this),
-      onChange: this.handleFieldChange.bind(this, fieldName)
+      onChange: this.handleFieldChange.bind(this, target.ref)
     });
   }
 

--- a/src/lib/DatePickerComponent.android.js
+++ b/src/lib/DatePickerComponent.android.js
@@ -162,7 +162,7 @@ export class DatePickerComponent extends React.Component {
     const valueTestId = this.state.date
       ? `Value/${this.state.date?.getTime()}`
       : "Unknown";
-
+    const showClear = !!(iconClear && valueString);
     return (
       <View>
         <Field {...this.props} ref="inputBox" onPress={this._togglePicker}>
@@ -180,7 +180,7 @@ export class DatePickerComponent extends React.Component {
               <Text testID={valueTestId} style={this.props.valueStyle}>
                 {valueString}
               </Text>
-              {iconClear && valueString ? (
+              {showClear ? (
                 <TouchableContainer
                   tid={`ClearDateValue`}
                   onPress={this.handleClear}
@@ -188,7 +188,7 @@ export class DatePickerComponent extends React.Component {
                   {iconClear}
                 </TouchableContainer>
               ) : null}
-              {!iconClear && iconRight ? (
+              {!showClear && iconRight ? (
                 <TouchableContainer
                   tid={`ToggleDatePicker`}
                   onPress={this._togglePicker}

--- a/src/lib/DatePickerComponent.android.js
+++ b/src/lib/DatePickerComponent.android.js
@@ -188,7 +188,7 @@ export class DatePickerComponent extends React.Component {
                   {iconClear}
                 </TouchableContainer>
               ) : null}
-              {iconRight ? (
+              {!iconClear && iconRight ? (
                 <TouchableContainer
                   tid={`ToggleDatePicker`}
                   onPress={this._togglePicker}

--- a/src/lib/DatePickerComponent.ios.js
+++ b/src/lib/DatePickerComponent.ios.js
@@ -154,7 +154,7 @@ export class DatePickerComponent extends React.Component {
       : "Unknown";
     const iconLeft = getIcon(this.state.isPickerVisible, this.props.iconLeft);
     const iconRight = getIcon(this.state.isPickerVisible, this.props.iconRight);
-
+    const showClear = !!(iconClear && valueString);
     return (
       <View>
         <Field {...this.props} ref="inputBox" onPress={this._togglePicker}>
@@ -172,7 +172,7 @@ export class DatePickerComponent extends React.Component {
               <Text tid={valueTestId} style={[this.props.valueStyle]}>
                 {valueString}
               </Text>
-              {iconClear && valueString ? (
+              {showClear ? (
                 <TouchableContainer
                   tid={`RemoveDateValue`}
                   onPress={this.handleClear}
@@ -180,7 +180,7 @@ export class DatePickerComponent extends React.Component {
                   {iconClear}
                 </TouchableContainer>
               ) : null}
-              {!iconClear && iconRight ? (
+              {!showClear && iconRight ? (
                 <TouchableContainer
                   tid={`ToggleDatePicker`}
                   onPress={this._togglePicker}

--- a/src/lib/DatePickerComponent.ios.js
+++ b/src/lib/DatePickerComponent.ios.js
@@ -180,7 +180,7 @@ export class DatePickerComponent extends React.Component {
                   {iconClear}
                 </TouchableContainer>
               ) : null}
-              {iconRight ? (
+              {!iconClear && iconRight ? (
                 <TouchableContainer
                   tid={`ToggleDatePicker`}
                   onPress={this._togglePicker}

--- a/src/lib/DatePickerComponent.windows.js
+++ b/src/lib/DatePickerComponent.windows.js
@@ -182,7 +182,7 @@ export class DatePickerComponent extends React.Component {
     const valueTestId = this.state.date
       ? `Value/${this.state.date?.getTime()}`
       : "Unknown";
-
+    const showClear = !!(iconClear && valueString);
     return (
       <View>
         <Field {...this.props} ref="inputBox" onPress={this._togglePicker}>
@@ -200,7 +200,7 @@ export class DatePickerComponent extends React.Component {
               <Text testID={valueTestId} style={this.props.valueStyle}>
                 {valueString}
               </Text>
-              {iconClear && valueString ? (
+              {showClear ? (
                 <TouchableContainer
                   tid={`ClearDateValue`}
                   onPress={this.handleClear}
@@ -208,7 +208,7 @@ export class DatePickerComponent extends React.Component {
                   {iconClear}
                 </TouchableContainer>
               ) : null}
-              {!iconClear && iconRight ? (
+              {!showClear && iconRight ? (
                 <TouchableContainer
                   tid={`ToggleDatePicker`}
                   onPress={this._togglePicker}

--- a/src/lib/DatePickerComponent.windows.js
+++ b/src/lib/DatePickerComponent.windows.js
@@ -208,7 +208,7 @@ export class DatePickerComponent extends React.Component {
                   {iconClear}
                 </TouchableContainer>
               ) : null}
-              {iconRight ? (
+              {!iconClear && iconRight ? (
                 <TouchableContainer
                   tid={`ToggleDatePicker`}
                   onPress={this._togglePicker}


### PR DESCRIPTION
Ties in with an upcoming PR to add support for sections with columns in flows by adding the `onChange`, `onFocus`, etc props to the fields that are in the in the columns