### PR TITLE
Allow Empty Date field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@axsy-dev/react-native-form-generator",
-  "version": "0.9.36",
+  "version": "0.9.39-a",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@axsy-dev/react-native-form-generator",
-      "version": "0.9.36",
+      "version": "0.9.39-a",
       "license": "MIT",
       "dependencies": {
         "@react-native-picker/picker": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "test:watch": "jest --watchAll",
     "format": "prettier --write --loglevel=silent"
   },
-  "version": "0.9.38",
+  "version": "0.9.39",
   "devDependencies": {
     "@tsconfig/react-native": "^1.0.4",
     "@types/react": "^17.0.39",

--- a/src/lib/DatePickerComponent.android.js
+++ b/src/lib/DatePickerComponent.android.js
@@ -35,7 +35,7 @@ export class DatePickerComponent extends React.Component {
 
   UNSAFE_componentWillMount() {
     if (this.props.date) {
-      const dateToSet = normalizeAndFormat(this.props);
+      const dateToSet = this.props.noInitialDate ? "" : normalizeAndFormat(this.props);
 
       this.setState({ date: dateToSet });
     }

--- a/src/lib/DatePickerComponent.android.js
+++ b/src/lib/DatePickerComponent.android.js
@@ -225,7 +225,8 @@ export class DatePickerComponent extends React.Component {
 }
 
 DatePickerComponent.propTypes = {
-  dateTimeFormat: PropTypes.func
+  dateTimeFormat: PropTypes.func,
+  noInitialDate: PropTypes.bool
 };
 
 DatePickerComponent.defaultProps = {

--- a/src/lib/DatePickerComponent.ios.js
+++ b/src/lib/DatePickerComponent.ios.js
@@ -34,7 +34,7 @@ export class DatePickerComponent extends React.Component {
 
   UNSAFE_componentWillMount() {
     if (this.props.date) {
-      const dateToSet = normalizeAndFormat(this.props);
+      const dateToSet = this.props.noInitialDate ? "" : normalizeAndFormat(this.props);
       this.setState({ date: dateToSet });
     }
   }

--- a/src/lib/DatePickerComponent.ios.js
+++ b/src/lib/DatePickerComponent.ios.js
@@ -207,7 +207,8 @@ function getIcon(isPickerVisible, icons) {
 DatePickerComponent.propTypes = {
   dateTimeFormat: PropTypes.func,
   pickerWrapper: PropTypes.element,
-  prettyPrint: PropTypes.bool
+  prettyPrint: PropTypes.bool,
+  noInitialDate: PropTypes.bool
 };
 
 DatePickerComponent.defaultProps = {

--- a/src/lib/DatePickerComponent.windows.js
+++ b/src/lib/DatePickerComponent.windows.js
@@ -240,7 +240,8 @@ export class DatePickerComponent extends React.Component {
 }
 
 DatePickerComponent.propTypes = {
-  dateTimeFormat: PropTypes.func
+  dateTimeFormat: PropTypes.func,
+  noInitialDate: PropTypes.bool
 };
 
 DatePickerComponent.defaultProps = {

--- a/src/lib/DatePickerComponent.windows.js
+++ b/src/lib/DatePickerComponent.windows.js
@@ -36,7 +36,7 @@ export class DatePickerComponent extends React.Component {
   }
 
   UNSAFE_componentWillMount() {
-    const dateToSet = normalizeAndFormat(this.props);
+    const dateToSet = this.props.noInitialDate ? "" : normalizeAndFormat(this.props);
 
     this.setState({ date: dateToSet });
   }


### PR DESCRIPTION
What: Allow date picker component to optionally be mounted with an empty string

Why: Some date fields are `nillable `and not `defaultedOnCreate`, so we don't necessarily want to provide a starting value for these fields. If they have a value they are added to the validation rules logic and validated in-app, whereas some of our customers are running validation logic for these nillable fields once their synced up to salesforce. Additionally with the current logic it is possible to have contrived situations in react-app where the EndDate starts with a default date that is prior to the StartDate, which causes validation checks to fail


See Issue https://github.com/axsy-dev/react-app/issues/8915
