### PR TITLE
Make date field value nullable

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "test:watch": "jest --watchAll",
     "format": "prettier --write --loglevel=silent"
   },
-  "version": "0.9.39",
+  "version": "0.9.40",
   "devDependencies": {
     "@tsconfig/react-native": "^1.0.4",
     "@types/react": "^17.0.39",

--- a/src/lib/DatePickerComponent.android.js
+++ b/src/lib/DatePickerComponent.android.js
@@ -35,7 +35,9 @@ export class DatePickerComponent extends React.Component {
 
   UNSAFE_componentWillMount() {
     if (this.props.date) {
-      const dateToSet = this.props.noInitialDate ? "" : normalizeAndFormat(this.props);
+      const dateToSet = this.props.noInitialDate
+        ? null
+        : normalizeAndFormat(this.props);
 
       this.setState({ date: dateToSet });
     }
@@ -66,7 +68,7 @@ export class DatePickerComponent extends React.Component {
         onValueChange(dateToSet);
       }
     } else {
-      this.setState({ date: "" });
+      this.setState({ date: null });
 
       if (onChange) {
         onChange(date);
@@ -107,7 +109,7 @@ export class DatePickerComponent extends React.Component {
         onValueChange(dateToSet);
       }
     } else {
-      this.setState({ date: "" });
+      this.setState({ date: null });
 
       if (onChange) {
         onChange(date);
@@ -144,9 +146,9 @@ export class DatePickerComponent extends React.Component {
     const { mode } = this.props;
 
     if (mode === "time") {
-      this.handleTimeValueChange(e, "");
+      this.handleTimeValueChange(e, null);
     } else {
-      this.handleDateValueChange(e, "");
+      this.handleDateValueChange(e, null);
     }
   }
 

--- a/src/lib/DatePickerComponent.ios.js
+++ b/src/lib/DatePickerComponent.ios.js
@@ -34,7 +34,7 @@ export class DatePickerComponent extends React.Component {
 
   UNSAFE_componentWillMount() {
     if (this.props.date) {
-      const dateToSet = this.props.noInitialDate ? "" : normalizeAndFormat(this.props);
+      const dateToSet = this.props.noInitialDate ? null : normalizeAndFormat(this.props);
       this.setState({ date: dateToSet });
     }
   }
@@ -56,7 +56,7 @@ export class DatePickerComponent extends React.Component {
         this.setState({ date: dateToSet });
       }
     } else if (this.state.date) {
-      this.setState({ date: "" });
+      this.setState({ date: null });
     }
   }
 
@@ -90,7 +90,7 @@ export class DatePickerComponent extends React.Component {
         onValueChange(dateToSet);
       }
     } else {
-      this.setState({ date: "" });
+      this.setState({ date: null });
 
       if (onChange) {
         onChange(date);
@@ -139,7 +139,7 @@ export class DatePickerComponent extends React.Component {
   }
 
   handleClear(e) {
-    this.handleValueChange(e, "");
+    this.handleValueChange(e, null);
   }
 
   render() {

--- a/src/lib/DatePickerComponent.windows.js
+++ b/src/lib/DatePickerComponent.windows.js
@@ -36,7 +36,7 @@ export class DatePickerComponent extends React.Component {
   }
 
   UNSAFE_componentWillMount() {
-    const dateToSet = this.props.noInitialDate ? "" : normalizeAndFormat(this.props);
+    const dateToSet = this.props.noInitialDate ? null : normalizeAndFormat(this.props);
 
     this.setState({ date: dateToSet });
   }
@@ -153,14 +153,14 @@ export class DatePickerComponent extends React.Component {
   handleClear() {
     const { onChange, onValueChange } = this.props;
 
-    this.setState({ date: "" });
+    this.setState({ date: null });
 
     if (onChange) {
-      onChange("");
+      onChange(null);
     }
 
     if (onValueChange) {
-      onValueChange("");
+      onValueChange(null);
     }
   }
 


### PR DESCRIPTION
What: follow on from https://github.com/axsy-dev/react-native-form-generator/pull/28 and https://github.com/axsy-dev/react-app/issues/8915. Allow the value of the field to be null so we can safely check for field.nullable and allow empty strings to be treated as valid inputs

Why: https://github.com/axsy-dev/react-app/issues/8915