### PR TITLE
Rename unsafe methods

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@axsy-dev/react-native-form-generator",
-  "version": "0.9.39-a",
+  "version": "0.9.41",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@axsy-dev/react-native-form-generator",
-      "version": "0.9.39-a",
+      "version": "0.9.41",
       "license": "MIT",
       "dependencies": {
         "@react-native-picker/picker": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "test:watch": "jest --watchAll",
     "format": "prettier --write --loglevel=silent"
   },
-  "version": "0.9.40",
+  "version": "0.9.41",
   "devDependencies": {
     "@tsconfig/react-native": "^1.0.4",
     "@types/react": "^17.0.39",

--- a/src/lib/DateTimeSelector.windows.js
+++ b/src/lib/DateTimeSelector.windows.js
@@ -112,7 +112,7 @@ class DateTimeSelector extends Component {
     };
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     const { date } = this.props;
 
     if (date) {

--- a/src/lib/InputComponent.tsx
+++ b/src/lib/InputComponent.tsx
@@ -104,7 +104,7 @@ export class InputComponent extends React.Component<Props, State> {
     };
   }
 
-  componentWillReceiveProps(nextProps: Props) {
+  UNSAFE_componentWillReceiveProps(nextProps: Props) {
     if (this.state.value !== nextProps.value) {
       this.handleChange(nextProps.value || "");
     }


### PR DESCRIPTION
Will get rid of this warning in react-app:

```
 WARN  Warning: componentWillReceiveProps has been renamed, and is not recommended for use. See https://reactjs.org/link/unsafe-component-lifecycles for details.

* Move data fetching code or side effects to componentDidUpdate.
* If you're updating state whenever props change, refactor your code to use memoization techniques or move it to static getDerivedStateFromProps. Learn more at: https://reactjs.org/link/derived-state
* Rename componentWillReceiveProps to UNSAFE_componentWillReceiveProps to suppress this warning in non-strict mode. In React 18.x, only the UNSAFE_ name will work. To rename all deprecated lifecycles to their new names, you can run `npx react-codemod rename-unsafe-lifecycles` in your project source folder.

Please update the following components: InputComponent
```