### PR TITLE
Fix time picker's dropdown arrow appearing on the next line

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@axsy-dev/react-native-form-generator",
-  "version": "0.9.41",
+  "version": "0.9.42",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@axsy-dev/react-native-form-generator",
-      "version": "0.9.41",
+      "version": "0.9.42",
       "license": "MIT",
       "dependencies": {
         "@react-native-picker/picker": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "test:watch": "jest --watchAll",
     "format": "prettier --write --loglevel=silent"
   },
-  "version": "0.9.41",
+  "version": "0.9.42",
   "devDependencies": {
     "@tsconfig/react-native": "^1.0.4",
     "@types/react": "^17.0.39",

--- a/src/lib/TimePickerComponent.android.js
+++ b/src/lib/TimePickerComponent.android.js
@@ -7,6 +7,7 @@ import { View, Text } from "react-native";
 import DateTimePicker from "@react-native-community/datetimepicker";
 
 import { Field } from "./Field";
+import { TouchableContainer } from "./TouchableContainer";
 
 export class TimePickerComponent extends React.Component {
   constructor(props) {
@@ -87,8 +88,15 @@ export class TimePickerComponent extends React.Component {
               <Text testID={`Value`} style={[this.props.valueStyle]}>
                 {this.props.dateTimeFormat(this.state.date)}
               </Text>
+              {this.props.iconRight ? (
+                <TouchableContainer
+                  tid={`ToggleDatePicker`}
+                  onPress={this._togglePicker.bind(this)}
+                >
+                  {this.props.iconRight}
+                </TouchableContainer>
+              ) : null}
             </View>
-            {this.props.iconRight ? this.props.iconRight : null}
           </View>
         </Field>
         {this.state.isTimePickerVisible ? (

--- a/src/lib/TimePickerComponent.android.js
+++ b/src/lib/TimePickerComponent.android.js
@@ -57,7 +57,7 @@ export class TimePickerComponent extends React.Component {
     if (this.props.onValueChange) this.props.onValueChange(date);
   }
 
-  async _togglePicker(event) {
+  _togglePicker = async (event) => {
     this.setState({ isTimePickerVisible: true });
     this.props.onPress && this.props.onPress(event);
   }
@@ -77,7 +77,7 @@ export class TimePickerComponent extends React.Component {
         <Field
           {...this.props}
           ref="inputBox"
-          onPress={this._togglePicker.bind(this)}
+          onPress={this._togglePicker}
         >
           <View
             style={this.props.containerStyle}
@@ -85,13 +85,13 @@ export class TimePickerComponent extends React.Component {
           >
             {placeholderComponent}
             <View style={this.props.valueContainerStyle}>
-              <Text testID={`Value`} style={[this.props.valueStyle]}>
+              <Text testID="Value" style={[this.props.valueStyle]}>
                 {this.props.dateTimeFormat(this.state.date)}
               </Text>
               {this.props.iconRight ? (
                 <TouchableContainer
-                  tid={`ToggleDatePicker`}
-                  onPress={this._togglePicker.bind(this)}
+                  tid="ToggleDatePicker"
+                  onPress={this._togglePicker}
                 >
                   {this.props.iconRight}
                 </TouchableContainer>


### PR DESCRIPTION
Fixed https://github.com/axsy-dev/react-app/issues/9240 by moving the right icon into the value container view - following the same pattern as the [`DateTimePicker` components](https://github.com/axsy-dev/react-native-form-generator/blob/master/src/lib/DatePickerComponent.ios.js)