### PR TITLE
Fix date picker component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@axsy-dev/react-native-form-generator",
-  "version": "0.9.43",
+  "version": "0.9.44",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@axsy-dev/react-native-form-generator",
-      "version": "0.9.43",
+      "version": "0.9.44",
       "license": "MIT",
       "dependencies": {
         "@react-native-picker/picker": "^2.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@axsy-dev/react-native-form-generator",
-  "version": "0.9.44",
+  "version": "0.9.45",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@axsy-dev/react-native-form-generator",
-      "version": "0.9.44",
+      "version": "0.9.45",
       "license": "MIT",
       "dependencies": {
         "@react-native-picker/picker": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "test:watch": "jest --watchAll",
     "format": "prettier --write --loglevel=silent"
   },
-  "version": "0.9.44",
+  "version": "0.9.45",
   "devDependencies": {
     "@tsconfig/react-native": "^1.0.4",
     "@types/react": "^17.0.39",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "test:watch": "jest --watchAll",
     "format": "prettier --write --loglevel=silent"
   },
-  "version": "0.9.43",
+  "version": "0.9.44",
   "devDependencies": {
     "@tsconfig/react-native": "^1.0.4",
     "@types/react": "^17.0.39",

--- a/src/lib/DatePickerComponent.ios.js
+++ b/src/lib/DatePickerComponent.ios.js
@@ -39,7 +39,7 @@ export class DatePickerComponent extends React.Component {
     }
   }
 
-  UNSAFE_componentDidUpdate(_prevProps, _prevState, snapshot) {
+  componentDidUpdate(_prevProps, _prevState, snapshot) {
     const { date } = this.props;
 
     if (date) {


### PR DESCRIPTION
Removes the `UNSAFE_` from the start of `componentDidUpdate` as the function wasn't running meaning the date component's `date` state was one update behind the prop's `date`

I bumped the packaged version to 0.9.45 because I saw an error with 0.9.44: `tag 'v0.9.44' already exists`