### PR TITLE
refactor(InputComponent): text input testID set using props or default to 'Input'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@axsy-dev/react-native-form-generator",
-  "version": "0.9.46",
+  "version": "0.9.47",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@axsy-dev/react-native-form-generator",
-      "version": "0.9.46",
+      "version": "0.9.47",
       "license": "MIT",
       "dependencies": {
         "@react-native-picker/picker": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "test:watch": "jest --watchAll",
     "format": "prettier --write --loglevel=silent"
   },
-  "version": "0.9.46",
+  "version": "0.9.47",
   "devDependencies": {
     "@tsconfig/react-native": "^1.0.4",
     "@types/react": "^17.0.39",

--- a/src/lib/InputComponent.tsx
+++ b/src/lib/InputComponent.tsx
@@ -291,7 +291,7 @@ export class InputComponent extends React.Component<Props, State> {
           <TextInput
             {...this.props}
             ref={this.saveRef}
-            testID="Input"
+            testID={this.props.testID ?? "Input"}
             keyboardType={this.props.keyboardType}
             style={this.props.inputStyle}
             onChange={this.handleChangeFromInput}


### PR DESCRIPTION
This PR refactors the `TextField` in `Inputcomponent` file to set the `TextInput` testID if exists in props, otherwise it uses the default "Input". 

[Requested change](https://github.com/axsy-dev/react-app/pull/10203#pullrequestreview-1765408966)