### PR TITLE
Allow callers of Form to respond to individual field changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@axsy-dev/react-native-form-generator",
-  "version": "0.9.47",
+  "version": "0.9.48",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@axsy-dev/react-native-form-generator",
-      "version": "0.9.47",
+      "version": "0.9.48",
       "license": "MIT",
       "dependencies": {
         "@react-native-picker/picker": "^2.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@axsy-dev/react-native-form-generator",
-  "version": "0.9.48",
+  "version": "0.9.49",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@axsy-dev/react-native-form-generator",
-      "version": "0.9.48",
+      "version": "0.9.49",
       "license": "MIT",
       "dependencies": {
         "@react-native-picker/picker": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "test:watch": "jest --watchAll",
     "format": "prettier --write --loglevel=silent"
   },
-  "version": "0.9.47",
+  "version": "0.9.48",
   "devDependencies": {
     "@tsconfig/react-native": "^1.0.4",
     "@types/react": "^17.0.39",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "test:watch": "jest --watchAll",
     "format": "prettier --write --loglevel=silent"
   },
-  "version": "0.9.48",
+  "version": "0.9.49",
   "devDependencies": {
     "@tsconfig/react-native": "^1.0.4",
     "@types/react": "^17.0.39",

--- a/src/Form.js
+++ b/src/Form.js
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import { Text, View } from "react-native";
+import { View } from "react-native";
 
 export class Form extends Component {
   constructor(props) {
@@ -9,18 +9,14 @@ export class Form extends Component {
   }
 
   handleFieldFocused(event, inputHandle) {
-    this.props.onFocus && this.props.onFocus(event, inputHandle);
+    this.props.onFocus?.(event, inputHandle);
   }
 
   handleFieldChange(field_ref, value) {
-    if (typeof field_ref === "function") {
-      const ref = field_ref && field_ref();
-      this.values[ref] = value;
-    } else {
-      this.values[field_ref] = value;
-    }
-
-    this.props.onChange && this.props.onChange(this.values);
+    const name = typeof field_ref === "function" ? field_ref() : field_ref;
+    this.values[name] = value;
+    this.props.onChange?.(this.values);
+    this.props.onFieldChange?.(name, value);
   }
 
   getValues() {


### PR DESCRIPTION
- Small tidy up
- Add a call to onFieldChange prop from handleFieldChange to allow callers of the form to respond to individual field changes, rather than updates to the whole form

The motivation for this is an issue with flow reactivity where sending all the values of the form as a change causes an infinite loop of reactive changes.

This PR on it's own might break generic object modals that use AxsyForm in react-app because AxsyForm overrides `Form.handleFieldChange` with a method which calls the `super.handleFieldChange` and the `onFieldChange` prop (meaning in the time between this being merged back and a separate PR in react-app to remove the call to the `onFieldChange` prop is removed, the prop will be called twice)