### PR TITLE
Add / fix support for disabled and readonly fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@axsy-dev/react-native-form-generator",
-  "version": "0.9.50",
+  "version": "0.9.51",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@axsy-dev/react-native-form-generator",
-      "version": "0.9.50",
+      "version": "0.9.51",
       "license": "MIT",
       "dependencies": {
         "@react-native-picker/picker": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "test:watch": "jest --watchAll",
     "format": "prettier --write --loglevel=silent"
   },
-  "version": "0.9.50",
+  "version": "0.9.51",
   "devDependencies": {
     "@tsconfig/react-native": "^1.0.4",
     "@types/react": "^17.0.39",

--- a/src/lib/DatePickerComponent.android.js
+++ b/src/lib/DatePickerComponent.android.js
@@ -153,7 +153,8 @@ export class DatePickerComponent extends React.Component {
   }
 
   render() {
-    const { placeholderComponent, iconClear, iconRight, iconLeft } = this.props;
+    const { placeholderComponent, iconClear, iconRight, iconLeft, editable } =
+      this.props;
 
     const valueString = this.state.date
       ? this.props.dateTimeFormat(this.state.date, this.props.mode)
@@ -165,6 +166,7 @@ export class DatePickerComponent extends React.Component {
       ? `Value/${this.state.date?.getTime()}`
       : "Unknown";
     const showClear = !!(iconClear && valueString);
+    const onPress = editable ? this._togglePicker : () => {};
     return (
       <View>
         <Field {...this.props} ref="inputBox" onPress={this._togglePicker}>
@@ -172,7 +174,7 @@ export class DatePickerComponent extends React.Component {
             style={this.props.containerStyle}
             onLayout={this.handleLayoutChange}
           >
-            {active && iconLeft ? iconLeft : null}
+            {editable && iconLeft ? iconLeft : null}
             {placeholderComponent ? (
               placeholderComponent
             ) : (
@@ -182,7 +184,7 @@ export class DatePickerComponent extends React.Component {
               <Text testID={valueTestId} style={this.props.valueStyle}>
                 {valueString}
               </Text>
-              {active && showClear ? (
+              {editable && showClear ? (
                 <TouchableContainer
                   tid={`ClearDateValue`}
                   onPress={this.handleClear}
@@ -190,7 +192,7 @@ export class DatePickerComponent extends React.Component {
                   {iconClear}
                 </TouchableContainer>
               ) : null}
-              {active && !showClear && iconRight ? (
+              {editable && !showClear && iconRight ? (
                 <TouchableContainer
                   tid={`ToggleDatePicker`}
                   onPress={this._togglePicker}

--- a/src/lib/DatePickerComponent.android.js
+++ b/src/lib/DatePickerComponent.android.js
@@ -172,7 +172,7 @@ export class DatePickerComponent extends React.Component {
             style={this.props.containerStyle}
             onLayout={this.handleLayoutChange}
           >
-            {iconLeft ? iconLeft : null}
+            {active && iconLeft ? iconLeft : null}
             {placeholderComponent ? (
               placeholderComponent
             ) : (
@@ -182,7 +182,7 @@ export class DatePickerComponent extends React.Component {
               <Text testID={valueTestId} style={this.props.valueStyle}>
                 {valueString}
               </Text>
-              {showClear ? (
+              {active && showClear ? (
                 <TouchableContainer
                   tid={`ClearDateValue`}
                   onPress={this.handleClear}
@@ -190,7 +190,7 @@ export class DatePickerComponent extends React.Component {
                   {iconClear}
                 </TouchableContainer>
               ) : null}
-              {!showClear && iconRight ? (
+              {active && !showClear && iconRight ? (
                 <TouchableContainer
                   tid={`ToggleDatePicker`}
                   onPress={this._togglePicker}

--- a/src/lib/DatePickerComponent.android.js
+++ b/src/lib/DatePickerComponent.android.js
@@ -2,7 +2,7 @@
 
 import React from "react";
 import PropTypes from "prop-types";
-import { View, Text } from "react-native";
+import { View, Text, TextInput } from "react-native";
 import DateTimePicker from "@react-native-community/datetimepicker";
 import { Field } from "./Field";
 
@@ -153,8 +153,14 @@ export class DatePickerComponent extends React.Component {
   }
 
   render() {
-    const { placeholderComponent, iconClear, iconRight, iconLeft, editable } =
-      this.props;
+    const {
+      placeholderComponent,
+      iconClear,
+      iconRight,
+      iconLeft,
+      editable = true,
+      readonly = false
+    } = this.props;
 
     const valueString = this.state.date
       ? this.props.dateTimeFormat(this.state.date, this.props.mode)
@@ -166,25 +172,33 @@ export class DatePickerComponent extends React.Component {
       ? `Value/${this.state.date?.getTime()}`
       : "Unknown";
     const showClear = !!(iconClear && valueString);
-    const onPress = editable ? this._togglePicker : () => {};
+    const active = editable && !readonly;
+    const onPress = active ? this._togglePicker : null;
     return (
       <View>
-        <Field {...this.props} ref="inputBox" onPress={this._togglePicker}>
+        <Field {...this.props} ref="inputBox" onPress={onPress}>
           <View
             style={this.props.containerStyle}
             onLayout={this.handleLayoutChange}
           >
-            {editable && iconLeft ? iconLeft : null}
+            {active && iconLeft ? iconLeft : null}
             {placeholderComponent ? (
               placeholderComponent
             ) : (
               <DatePickerPlaceholder {...this.props} />
             )}
             <View style={this.props.valueContainerStyle}>
-              <Text testID={valueTestId} style={this.props.valueStyle}>
-                {valueString}
-              </Text>
-              {editable && showClear ? (
+              {readonly ? (
+                <TextInput
+                  value={valueString}
+                  style={[this.props.valueStyle, { flex: 1 }]}
+                />
+              ) : (
+                <Text testID={valueTestId} style={this.props.valueStyle}>
+                  {valueString}
+                </Text>
+              )}
+              {active && showClear ? (
                 <TouchableContainer
                   tid={`ClearDateValue`}
                   onPress={this.handleClear}
@@ -192,10 +206,10 @@ export class DatePickerComponent extends React.Component {
                   {iconClear}
                 </TouchableContainer>
               ) : null}
-              {editable && !showClear && iconRight ? (
+              {active && !showClear && iconRight ? (
                 <TouchableContainer
                   tid={`ToggleDatePicker`}
-                  onPress={this._togglePicker}
+                  onPress={!readonly ? this._togglePicker : () => {}}
                 >
                   {iconRight}
                 </TouchableContainer>

--- a/src/lib/DatePickerComponent.ios.js
+++ b/src/lib/DatePickerComponent.ios.js
@@ -145,7 +145,7 @@ export class DatePickerComponent extends React.Component {
   }
 
   render() {
-    const { placeholderComponent, iconClear, editable: active } = this.props;
+    const { placeholderComponent, iconClear, editable } = this.props;
     const valueString = this.state.date
       ? this.props.dateTimeFormat(this.state.date, this.props.mode)
       : "";
@@ -156,18 +156,15 @@ export class DatePickerComponent extends React.Component {
     const iconLeft = getIcon(this.state.isPickerVisible, this.props.iconLeft);
     const iconRight = getIcon(this.state.isPickerVisible, this.props.iconRight);
     const showClear = !!(iconClear && valueString);
+    const onPress = editable ? this._togglePicker : () => {};
     return (
       <View>
-        <Field
-          {...this.props}
-          ref="inputBox"
-          onPress={active ? this._togglePicker : () => {}}
-        >
+        <Field {...this.props} ref="inputBox" onPress={onPress}>
           <View
             style={[this.props.containerStyle]}
             onLayout={this.handleLayoutChange}
           >
-            {active && iconLeft ? iconLeft : null}
+            {editable && iconLeft ? iconLeft : null}
             {placeholderComponent ? (
               placeholderComponent
             ) : (
@@ -177,7 +174,7 @@ export class DatePickerComponent extends React.Component {
               <Text testID={valueTestId} style={[this.props.valueStyle]}>
                 {valueString}
               </Text>
-              {active && showClear ? (
+              {editable && showClear ? (
                 <TouchableContainer
                   tid={`RemoveDateValue`}
                   onPress={this.handleClear}
@@ -185,7 +182,7 @@ export class DatePickerComponent extends React.Component {
                   {iconClear}
                 </TouchableContainer>
               ) : null}
-              {active && !showClear && iconRight ? (
+              {editable && !showClear && iconRight ? (
                 <TouchableContainer
                   tid={`ToggleDatePicker`}
                   onPress={this._togglePicker}

--- a/src/lib/DatePickerComponent.ios.js
+++ b/src/lib/DatePickerComponent.ios.js
@@ -34,7 +34,9 @@ export class DatePickerComponent extends React.Component {
 
   UNSAFE_componentWillMount() {
     if (this.props.date) {
-      const dateToSet = this.props.noInitialDate ? null : normalizeAndFormat(this.props);
+      const dateToSet = this.props.noInitialDate
+        ? null
+        : normalizeAndFormat(this.props);
       this.setState({ date: dateToSet });
     }
   }
@@ -143,8 +145,7 @@ export class DatePickerComponent extends React.Component {
   }
 
   render() {
-    const { placeholderComponent, iconClear } = this.props;
-
+    const { placeholderComponent, iconClear, editable: active } = this.props;
     const valueString = this.state.date
       ? this.props.dateTimeFormat(this.state.date, this.props.mode)
       : "";
@@ -157,12 +158,16 @@ export class DatePickerComponent extends React.Component {
     const showClear = !!(iconClear && valueString);
     return (
       <View>
-        <Field {...this.props} ref="inputBox" onPress={this._togglePicker}>
+        <Field
+          {...this.props}
+          ref="inputBox"
+          onPress={active ? this._togglePicker : () => {}}
+        >
           <View
             style={[this.props.containerStyle]}
             onLayout={this.handleLayoutChange}
           >
-            {iconLeft ? iconLeft : null}
+            {active && iconLeft ? iconLeft : null}
             {placeholderComponent ? (
               placeholderComponent
             ) : (
@@ -172,7 +177,7 @@ export class DatePickerComponent extends React.Component {
               <Text testID={valueTestId} style={[this.props.valueStyle]}>
                 {valueString}
               </Text>
-              {showClear ? (
+              {active && showClear ? (
                 <TouchableContainer
                   tid={`RemoveDateValue`}
                   onPress={this.handleClear}
@@ -180,7 +185,7 @@ export class DatePickerComponent extends React.Component {
                   {iconClear}
                 </TouchableContainer>
               ) : null}
-              {!showClear && iconRight ? (
+              {active && !showClear && iconRight ? (
                 <TouchableContainer
                   tid={`ToggleDatePicker`}
                   onPress={this._togglePicker}

--- a/src/lib/DatePickerComponent.ios.js
+++ b/src/lib/DatePickerComponent.ios.js
@@ -2,7 +2,7 @@
 
 import React from "react";
 import PropTypes from "prop-types";
-import { View, Text } from "react-native";
+import { View, Text, TextInput } from "react-native";
 import { Field } from "./Field";
 
 import DateTimePicker from "@react-native-community/datetimepicker";
@@ -145,7 +145,12 @@ export class DatePickerComponent extends React.Component {
   }
 
   render() {
-    const { placeholderComponent, iconClear, editable } = this.props;
+    const {
+      placeholderComponent,
+      iconClear,
+      editable = true,
+      readonly = false
+    } = this.props;
     const valueString = this.state.date
       ? this.props.dateTimeFormat(this.state.date, this.props.mode)
       : "";
@@ -156,7 +161,8 @@ export class DatePickerComponent extends React.Component {
     const iconLeft = getIcon(this.state.isPickerVisible, this.props.iconLeft);
     const iconRight = getIcon(this.state.isPickerVisible, this.props.iconRight);
     const showClear = !!(iconClear && valueString);
-    const onPress = editable ? this._togglePicker : () => {};
+    const active = editable && !readonly;
+    const onPress = active ? this._togglePicker : null;
     return (
       <View>
         <Field {...this.props} ref="inputBox" onPress={onPress}>
@@ -164,17 +170,24 @@ export class DatePickerComponent extends React.Component {
             style={[this.props.containerStyle]}
             onLayout={this.handleLayoutChange}
           >
-            {editable && iconLeft ? iconLeft : null}
+            {active && iconLeft ? iconLeft : null}
             {placeholderComponent ? (
               placeholderComponent
             ) : (
               <DatePickerPlaceholder {...this.props} />
             )}
             <View style={[this.props.valueContainerStyle]}>
-              <Text testID={valueTestId} style={[this.props.valueStyle]}>
-                {valueString}
-              </Text>
-              {editable && showClear ? (
+              {readonly ? (
+                <TextInput
+                  value={valueString}
+                  style={[this.props.valueStyle, { flex: 1 }]}
+                />
+              ) : (
+                <Text testID={valueTestId} style={[this.props.valueStyle]}>
+                  {valueString}
+                </Text>
+              )}
+              {active && showClear ? (
                 <TouchableContainer
                   tid={`RemoveDateValue`}
                   onPress={this.handleClear}
@@ -182,10 +195,10 @@ export class DatePickerComponent extends React.Component {
                   {iconClear}
                 </TouchableContainer>
               ) : null}
-              {editable && !showClear && iconRight ? (
+              {active && !showClear && iconRight ? (
                 <TouchableContainer
                   tid={`ToggleDatePicker`}
-                  onPress={this._togglePicker}
+                  onPress={readonly ? this._togglePicker : () => {}}
                 >
                   {iconRight}
                 </TouchableContainer>

--- a/src/lib/DatePickerComponent.windows.js
+++ b/src/lib/DatePickerComponent.windows.js
@@ -36,7 +36,9 @@ export class DatePickerComponent extends React.Component {
   }
 
   UNSAFE_componentWillMount() {
-    const dateToSet = this.props.noInitialDate ? null : normalizeAndFormat(this.props);
+    const dateToSet = this.props.noInitialDate
+      ? null
+      : normalizeAndFormat(this.props);
 
     this.setState({ date: dateToSet });
   }
@@ -165,7 +167,12 @@ export class DatePickerComponent extends React.Component {
   }
 
   render() {
-    const { placeholderComponent, iconRight, iconClear } = this.props;
+    const {
+      placeholderComponent,
+      iconRight,
+      iconClear,
+      editable: active
+    } = this.props;
     const valueString = this.state.date
       ? this.props.dateTimeFormat(this.state.date, this.props.mode)
       : "";
@@ -190,7 +197,7 @@ export class DatePickerComponent extends React.Component {
             style={this.props.containerStyle}
             onLayout={this.handleLayoutChange}
           >
-            {this.props.iconLeft ? this.props.iconLeft : null}
+            {active && this.props.iconLeft ? this.props.iconLeft : null}
             {placeholderComponent ? (
               placeholderComponent
             ) : (
@@ -200,7 +207,7 @@ export class DatePickerComponent extends React.Component {
               <Text testID={valueTestId} style={this.props.valueStyle}>
                 {valueString}
               </Text>
-              {showClear ? (
+              {active && showClear ? (
                 <TouchableContainer
                   tid={`ClearDateValue`}
                   onPress={this.handleClear}
@@ -208,7 +215,7 @@ export class DatePickerComponent extends React.Component {
                   {iconClear}
                 </TouchableContainer>
               ) : null}
-              {!showClear && iconRight ? (
+              {active && !showClear && iconRight ? (
                 <TouchableContainer
                   tid={`ToggleDatePicker`}
                   onPress={this._togglePicker}

--- a/src/lib/DatePickerComponent.windows.js
+++ b/src/lib/DatePickerComponent.windows.js
@@ -167,12 +167,7 @@ export class DatePickerComponent extends React.Component {
   }
 
   render() {
-    const {
-      placeholderComponent,
-      iconRight,
-      iconClear,
-      editable: active
-    } = this.props;
+    const { placeholderComponent, iconRight, iconClear, editable } = this.props;
     const valueString = this.state.date
       ? this.props.dateTimeFormat(this.state.date, this.props.mode)
       : "";
@@ -190,14 +185,15 @@ export class DatePickerComponent extends React.Component {
       ? `Value/${this.state.date?.getTime()}`
       : "Unknown";
     const showClear = !!(iconClear && valueString);
+    const onPress = editable ? this._togglePicker : () => {};
     return (
       <View>
-        <Field {...this.props} ref="inputBox" onPress={this._togglePicker}>
+        <Field {...this.props} ref="inputBox" onPress={onPress}>
           <View
             style={this.props.containerStyle}
             onLayout={this.handleLayoutChange}
           >
-            {active && this.props.iconLeft ? this.props.iconLeft : null}
+            {editable && this.props.iconLeft ? this.props.iconLeft : null}
             {placeholderComponent ? (
               placeholderComponent
             ) : (
@@ -207,7 +203,7 @@ export class DatePickerComponent extends React.Component {
               <Text testID={valueTestId} style={this.props.valueStyle}>
                 {valueString}
               </Text>
-              {active && showClear ? (
+              {editable && showClear ? (
                 <TouchableContainer
                   tid={`ClearDateValue`}
                   onPress={this.handleClear}
@@ -215,7 +211,7 @@ export class DatePickerComponent extends React.Component {
                   {iconClear}
                 </TouchableContainer>
               ) : null}
-              {active && !showClear && iconRight ? (
+              {editable && !showClear && iconRight ? (
                 <TouchableContainer
                   tid={`ToggleDatePicker`}
                   onPress={this._togglePicker}

--- a/src/lib/DatePickerComponent.windows.js
+++ b/src/lib/DatePickerComponent.windows.js
@@ -3,7 +3,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-import { View, Text } from "react-native";
+import { View, Text, TextInput } from "react-native";
 
 import DateTimePicker from "@react-native-community/datetimepicker";
 import { Field } from "./Field";
@@ -167,7 +167,13 @@ export class DatePickerComponent extends React.Component {
   }
 
   render() {
-    const { placeholderComponent, iconRight, iconClear, editable } = this.props;
+    const {
+      placeholderComponent,
+      iconRight,
+      iconClear,
+      editable = true,
+      readonly = false
+    } = this.props;
     const valueString = this.state.date
       ? this.props.dateTimeFormat(this.state.date, this.props.mode)
       : "";
@@ -185,7 +191,8 @@ export class DatePickerComponent extends React.Component {
       ? `Value/${this.state.date?.getTime()}`
       : "Unknown";
     const showClear = !!(iconClear && valueString);
-    const onPress = editable ? this._togglePicker : () => {};
+    const active = editable && !readonly;
+    const onPress = active ? this._togglePicker : null;
     return (
       <View>
         <Field {...this.props} ref="inputBox" onPress={onPress}>
@@ -193,17 +200,24 @@ export class DatePickerComponent extends React.Component {
             style={this.props.containerStyle}
             onLayout={this.handleLayoutChange}
           >
-            {editable && this.props.iconLeft ? this.props.iconLeft : null}
+            {active && this.props.iconLeft ? this.props.iconLeft : null}
             {placeholderComponent ? (
               placeholderComponent
             ) : (
               <DatePickerPlaceholder {...this.props} />
             )}
             <View style={this.props.valueContainerStyle}>
-              <Text testID={valueTestId} style={this.props.valueStyle}>
-                {valueString}
-              </Text>
-              {editable && showClear ? (
+              {readonly ? (
+                <TextInput
+                  value={valueString}
+                  style={[this.props.valueStyle, { flex: 1 }]}
+                />
+              ) : (
+                <Text testID={valueTestId} style={this.props.valueStyle}>
+                  {valueString}
+                </Text>
+              )}
+              {active && showClear ? (
                 <TouchableContainer
                   tid={`ClearDateValue`}
                   onPress={this.handleClear}
@@ -211,10 +225,10 @@ export class DatePickerComponent extends React.Component {
                   {iconClear}
                 </TouchableContainer>
               ) : null}
-              {editable && !showClear && iconRight ? (
+              {active && !showClear && iconRight ? (
                 <TouchableContainer
                   tid={`ToggleDatePicker`}
-                  onPress={this._togglePicker}
+                  onPress={!readonly ? this._togglePicker : () => {}}
                 >
                   {iconRight}
                 </TouchableContainer>

--- a/src/lib/InputComponent.tsx
+++ b/src/lib/InputComponent.tsx
@@ -41,6 +41,7 @@ type Props = TextInputProps & {
     event: NativeSyntheticEvent<TextInputFocusEventData>,
     handle: ReturnType<typeof findNodeHandle>
   ) => void;
+  readonly?: boolean;
 };
 
 type State = {
@@ -270,13 +271,15 @@ export class InputComponent extends React.Component<Props, State> {
   };
 
   render() {
+    const active = (this.props.editable ?? true) && !this.props.readonly;
+    const onChange = active ? this.handleChangeFromInput : undefined;
     return (
       <Field {...this.props}>
         <View
           onLayout={this.handleLayoutChange}
           style={this.props.containerStyle}
         >
-          {this.props.iconLeft ? this.props.iconLeft : null}
+          {active && this.props.iconLeft ? this.props.iconLeft : null}
           {this.props.label ? (
             <Text
               testID="Label"
@@ -294,14 +297,14 @@ export class InputComponent extends React.Component<Props, State> {
             testID={this.props.testID ?? "Input"}
             keyboardType={this.props.keyboardType}
             style={this.props.inputStyle}
-            onChange={this.handleChangeFromInput}
+            onChange={onChange}
             onContentSizeChange={this.handleContentSizeChange}
             onFocus={this._scrollToInput}
             placeholder={this.props.placeholder}
             value={this.state.displayValue}
             editable={this.props.editable}
           />
-          {this.props.iconRight ? this.props.iconRight : null}
+          {active && this.props.iconRight ? this.props.iconRight : null}
         </View>
       </Field>
     );

--- a/src/lib/InputComponent.tsx
+++ b/src/lib/InputComponent.tsx
@@ -299,6 +299,7 @@ export class InputComponent extends React.Component<Props, State> {
             onFocus={this._scrollToInput}
             placeholder={this.props.placeholder}
             value={this.state.displayValue}
+            editable={this.props.editable}
           />
           {this.props.iconRight ? this.props.iconRight : null}
         </View>

--- a/src/lib/InputComponent.tsx
+++ b/src/lib/InputComponent.tsx
@@ -302,7 +302,6 @@ export class InputComponent extends React.Component<Props, State> {
             onFocus={this._scrollToInput}
             placeholder={this.props.placeholder}
             value={this.state.displayValue}
-            editable={this.props.editable}
           />
           {active && this.props.iconRight ? this.props.iconRight : null}
         </View>


### PR DESCRIPTION
Part of a fix for https://github.com/axsy-dev/react-app/issues/10760

- Reestablishes support for input / date fields being to be disabled
- Allows selecting / copying from values when set as readonly, but prevents any input changing the value
- Hides any icons if a field is readonly or disabled - the issue doesn’t necessarily call for this, but think it makes it more clear that the field isn’t editable, happy to revert though!