### PR TITLE
Adds on cancel prop to date picker

### DIFF
--- a/src/lib/DatePickerComponent.ios.js
+++ b/src/lib/DatePickerComponent.ios.js
@@ -132,11 +132,8 @@ export class DatePickerComponent extends React.Component {
 
   _togglePicker(event) {
     if (this.context.actionSheet) {
-      this.context.actionSheet.showContent(
-        this._renderContent(),
-        undefined,
-        this.props.onCancel
-      );
+      const options = { onCancel: this.props.onCancel };
+      this.context.actionSheet.showContent(this._renderContent(), options);
     } else {
       this.setState({ isPickerVisible: !this.state.isPickerVisible });
     }

--- a/src/lib/DatePickerComponent.ios.js
+++ b/src/lib/DatePickerComponent.ios.js
@@ -132,7 +132,11 @@ export class DatePickerComponent extends React.Component {
 
   _togglePicker(event) {
     if (this.context.actionSheet) {
-      this.context.actionSheet.showContent(this._renderContent());
+      this.context.actionSheet.showContent(
+        this._renderContent(),
+        undefined,
+        this.props.onCancel
+      );
     } else {
       this.setState({ isPickerVisible: !this.state.isPickerVisible });
     }
@@ -223,7 +227,8 @@ DatePickerComponent.propTypes = {
   dateTimeFormat: PropTypes.func,
   pickerWrapper: PropTypes.element,
   prettyPrint: PropTypes.bool,
-  noInitialDate: PropTypes.bool
+  noInitialDate: PropTypes.bool,
+  onCancel: PropTypes.func
 };
 
 DatePickerComponent.defaultProps = {


### PR DESCRIPTION
**What:**
Adds an `onCancel` prop to the date picker component.
Uses the extended action sheet api to pass the prop through to a `showContent` action sheet.

**Why:**
Part of [ReactApp #11010](https://github.com/axsy-dev/react-app/issues/11010).