### PR TITLE
Maintenance/remove legacy string refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,14 +114,15 @@ export class FormView extends React.Component {
         style={{ paddingLeft: 10, paddingRight: 10, height: 200 }}
       >
         <Form
-          ref="registrationForm"
+          ref={this.formRef}
           onFocus={this.handleFormFocus.bind(this)}
           onChange={this.handleFormChange.bind(this)}
           label="Personal Information"
         >
           <Separator />
           <InputField
-            ref="first_name"
+            ref={this.firstNameRef}
+            fieldKey={"first_name"}
             label="First Name"
             placeholder="First Name"
             helpText={(self => {
@@ -162,22 +163,29 @@ export class FormView extends React.Component {
               }
             ]}
           />
-          <InputField ref="last_name" placeholder="Last Name" />
+          <InputField
+            fieldKey={"last_name"}
+            ref={this.lastNameRef}
+            placeholder="Last Name"
+          />
           <InputField
             multiline={true}
-            ref="other_input"
+            fieldKey={"other_input"}
+            ref={this.otherInputRef}
             placeholder="Other Input"
             helpText="this is an helpful text it can be also very very long and it will wrap"
           />
           <Separator />
           <LinkField label="test test test" onPress={() => {}} />
           <SwitchField
+            fieldKey={"has_accepted_conditions"}
             label="I accept Terms & Conditions"
-            ref="has_accepted_conditions"
+            ref={this.hasAcceptedRef}
             helpText="Please read carefully the terms & conditions"
           />
           <PickerField
-            ref="gender"
+            fieldKey={"gender"}
+            ref={this.genderRef}
             label="Gender"
             options={{
               "": "",
@@ -186,14 +194,20 @@ export class FormView extends React.Component {
             }}
           />
           <DatePickerField
-            ref="birthday"
+            fieldKey={"birthday"}
+            ref={this.birthdayRef}
             minimumDate={new Date("1/1/1900")}
             maximumDate={new Date()}
             placeholder="Birthday"
           />
-          <TimePickerField ref="alarm_time" placeholder="Set Alarm" />
+          <TimePickerField
+            fieldKey={"alarm"}
+            ref={this.alarmTimeRef}
+            placeholder="Set Alarm"
+          />
           <DatePickerField
-            ref="meeting"
+            fieldKey={"meeting"}
+            ref={this.meetingRef}
             minimumDate={new Date("1/1/1900")}
             maximumDate={new Date()}
             mode="datetime"
@@ -239,7 +253,7 @@ It's just a wrapper that allows you to attach onFocus (used to track focus event
 
 Input fields can be used to receive text, you can add icons (a react component) to the left and the right side of the field.
 
-InputField can validate values based on keyboardType property, validation is not "aggressive", just changes a value inside the class, you can access the value using the ref (ex. this.ref.example*input_field.valid).  
+InputField can validate values based on keyboardType property, validation is not "aggressive", just changes a value inside the class, you can access the value using the ref (ex. this.refName.current.valid).  
 InputField automatically provides the attibutes \_valid* and _validationErrors_ to guarantee full control to the developer.
 
 you can customize your validation function by adding a _validationFunction_ prop to the component. _validationFunction_ supports also an array of validators.
@@ -271,7 +285,8 @@ look at the example here.
 ```javascript
 <InputField
   label="Example" // if label is present the field is rendered with the value on the left (see First Name example in the gif), otherwise its rendered with textinput at full width (second name in the gif).
-  ref="example_input_field" // used in onChange event to collect the value
+  ref={this.exampleRef}
+  fieldKey="example_input_field"  // used in onChange event to collect the value
   value="default_value" // used as initial value
   keyboardType="" // undefined, 'email-address',
   validationFunction={value => {

--- a/README.md
+++ b/README.md
@@ -126,15 +126,11 @@ export class FormView extends React.Component {
             label="First Name"
             placeholder="First Name"
             helpText={(self => {
-              if (Object.keys(self.refs).length !== 0) {
-                if (!self.refs.registrationForm.refs.first_name.valid) {
-                  return self.refs.registrationForm.refs.first_name.validationErrors.join(
+                if (self.firstNameRef.current && !self.firstNameRef.current.valid) {
+                  return self.firstNameRef.current.validationErrors.join(
                     "\n"
                   );
-                }
               }
-              // if(!!(self.refs && self.refs.first_name.valid)){
-              // }
             })(this)}
             validationFunction={[
               value => {
@@ -300,8 +296,8 @@ look at the example here.
         { marginTop: 7, color: "#61d062" },
         (self => {
           //i can change the style of the component related to the attibute of example_input_field
-          if (!!(self.refs && self.refs.example_input_field)) {
-            if (!self.refs.example_input_field.valid)
+          if (!!self.exampleRef.current) {
+            if (!self.exampleRef.current.valid) 
               return { color: "#d52222" };
           }
         })(this)

--- a/examples/FormView.js
+++ b/examples/FormView.js
@@ -27,6 +27,20 @@ import {
 } from "react-native-form-generator";
 
 class CustomModal extends React.Component {
+  constructor(props) {
+    super(props);
+    this.formRef = React.createRef();
+    this.firstNameRef = React.createRef();
+    this.lastNameRef = React.createRef();
+    this.otherInputRef = React.createRef();
+    this.emailRef = React.createRef();
+    this.hasAcceptedRef = React.createRef();
+    this.genderRef = React.createRef();
+    this.birthdayRef = React.createRef();
+    this.alarmTimeRef = React.createRef();
+    this.countdownRef = React.createRef();
+    this.meetingRef = React.createRef();
+  }
   handleClose() {
     this.props.onHidePicker && this.props.onHidePicker();
   }
@@ -116,36 +130,33 @@ export class FormView extends React.Component {
   }
   openTermsAndConditionsURL() {}
   resetForm() {
-    this.refs.registrationForm.refs.first_name.setValue("");
-    this.refs.registrationForm.refs.last_name.setValue("");
-    this.refs.registrationForm.refs.other_input.setValue("");
-    this.refs.registrationForm.refs.meeting.setDate(new Date());
-    this.refs.registrationForm.refs.has_accepted_conditions.setValue(false);
+    this.firstNameRef.current && this.firstNameRef.current.setValue("");
+    this.lastNameRef.current && this.lastNameRef.current.setValue("");
+    this.otherInputRef.current && this.otherInputRef.current.setValue("");
+    this.meetingRef.current && this.meetingRef.current.setDate(new Date());
+    this.hasAcceptedRef.current && this.hasAcceptedRef.current.setValue(false);
   }
   render() {
     return (
       <ScrollView keyboardShouldPersistTaps={true} style={{ height: 200 }}>
         <Form
-          ref="registrationForm"
+          ref={this.formRef}
           onFocus={this.handleFormFocus.bind(this)}
           onChange={this.handleFormChange.bind(this)}
           label="Personal Information"
         >
           <Separator />
           <InputField
-            ref="first_name"
+            ref={this.firstNameRef}
+            fieldKey={"first_name"}
             label="First Name"
             placeholder="First Name"
             helpText={(self => {
-              if (Object.keys(self.refs).length !== 0) {
-                if (!self.refs.registrationForm.refs.first_name.valid) {
-                  return self.refs.registrationForm.refs.first_name.validationErrors.join(
-                    "\n"
-                  );
+              if (self.firstNameRef.current) {
+                if (!self.firstNameRef.current.valid) {
+                  return self.firstNameRef.current.validationErrors.join("\n");
                 }
               }
-              // if(!!(self.refs && self.refs.first_name.valid)){
-              // }
             })(this)}
             validationFunction={[
               value => {
@@ -173,6 +184,7 @@ export class FormView extends React.Component {
             ]}
           />
           <InputField
+            fieldKey={"last_name"}
             iconLeft={
               <WrappedIcon
                 style={{
@@ -184,18 +196,20 @@ export class FormView extends React.Component {
                 size={30}
               />
             }
-            ref="last_name"
+            ref={this.lastNameRef}
             value="Default Value"
             placeholder="Last Name"
           />
           <InputField
+            fieldKey={"other_input"}
             multiline={true}
-            ref="other_input"
+            ref={this.otherInputRef}
             placeholder="Other Input"
             helpText="this is an helpful text it can be also very very long and it will wrap"
           />
           <InputField
-            ref="email"
+            fieldKey={"email"}
+            ref={this.emailRef}
             value="test@test.it"
             keyboardType="email-address"
             placeholder="Email fields"
@@ -229,12 +243,14 @@ export class FormView extends React.Component {
             }
           />
           <SwitchField
+            fieldKey={"has_accepted_conditions"}
             label="I accept Terms & Conditions"
-            ref="has_accepted_conditions"
+            ref={this.hasAcceptedRef}
             helpText="Please read carefully the terms & conditions"
           />
           <PickerField
-            ref="gender"
+            fieldKey={"gender"}
+            ref={this.genderRef}
             label="Gender"
             value="female"
             options={[
@@ -244,7 +260,8 @@ export class FormView extends React.Component {
             ]}
           />
           <DatePickerField
-            ref="birthday"
+            fieldKey={"birthday"}
+            ref={this.birthdayRef}
             minimumDate={new Date("1/1/1900")}
             maximumDate={new Date()}
             iconRight={[
@@ -262,7 +279,8 @@ export class FormView extends React.Component {
             placeholder="Birthday"
           />
           <TimePickerField
-            ref="alarm_time"
+            fieldKey={"alarm"}
+            ref={this.alarmTimeRef}
             placeholder="Set Alarm"
             iconLeft={
               <Icon
@@ -275,12 +293,14 @@ export class FormView extends React.Component {
             pickerWrapper={<CustomModal />}
           />
           <CountDownField
-            ref="countdown"
+            fieldKey={"countdown"}
+            ref={this.countdownRef}
             label="CountDown"
             placeholder="11:00"
           />
           <DatePickerField
-            ref="meeting"
+            fieldKey={"meeting"}
+            ref={this.meetingRef}
             iconLeft={[
               <Icon
                 style={{ alignSelf: "center", marginLeft: 10 }}
@@ -317,7 +337,7 @@ export class FormView extends React.Component {
         </TouchableHighlight>
         <TouchableHighlight
           disabled={!this.state.formData.has_accepted_conditions}
-          onPress={() => this.refs.registrationForm.refs.other_input.focus()}
+          onPress={() => this.otherInputRef.current.focus()}
           underlayColor="#78ac05"
         >
           <View

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "test:watch": "jest --watchAll",
     "format": "prettier --write --loglevel=silent"
   },
-  "version": "0.10.0",
+  "version": "0.10.1",
   "devDependencies": {
     "@tsconfig/react-native": "^1.0.4",
     "@types/react": "^17.0.39",

--- a/src/Form.js
+++ b/src/Form.js
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import { Text, View } from "react-native";
+import { View } from "react-native";
 
 export class Form extends Component {
   constructor(props) {
@@ -12,10 +12,14 @@ export class Form extends Component {
     this.props.onFocus?.(event, inputHandle);
   }
 
-  handleFieldChange(field_ref, value) {
-    const name = typeof field_ref === "function" ? field_ref() : field_ref;
-    this.values[name] = value;
-    this.props.onChange?.({...this.values}, {[name]: value});
+  handleFieldChange(fieldKey, value) {
+    if (!fieldKey) {
+      console.warn('Field key is undefined. Cannot update value.');
+      return;
+    }
+
+    this.values[fieldKey] = value;
+    this.props.onChange?.({ ...this.values }, { [fieldKey]: value });
   }
 
   getValues() {
@@ -48,6 +52,7 @@ export class Form extends Component {
         this.addProps(fieldElement, isTestable, key)
       )
     );
+
     return isTestable
       ? React.cloneElement(sectionElement, { children: connectedTarget })
       : connectedTarget;
@@ -55,13 +60,16 @@ export class Form extends Component {
 
   addProps(element, isTestable, key) {
     const target = isTestable ? element.props.children : element;
+    const fieldKey = target.props.fieldKey || target.key;
+
     const targetWithProps = React.cloneElement(target, {
       key,
-      fieldRef: target.ref,
+      fieldKey,
       ref: target.ref,
       onFocus: this.handleFieldFocused.bind(this),
-      onChange: this.handleFieldChange.bind(this, target.ref)
+      onChange: this.handleFieldChange.bind(this, fieldKey)
     });
+
     return isTestable
       ? React.cloneElement(element, { children: targetWithProps })
       : targetWithProps;

--- a/src/KeyboardAwareScrollView.js
+++ b/src/KeyboardAwareScrollView.js
@@ -11,7 +11,7 @@ export class KeyboardAwareScrollView extends React.Component {
     this.state = {
       keyboardSpace: 0
     };
-
+    this.keyboardAwareScrollviewRef = React.createRef();
     this.updateKeyboardSpace = this.updateKeyboardSpace.bind(this);
     this.resetKeyboardSpace = this.resetKeyboardSpace.bind(this);
   }
@@ -54,21 +54,24 @@ export class KeyboardAwareScrollView extends React.Component {
    * @param extraHeight: takes an extra height in consideration.
    */
   scrollToFocusedInput(event, reactNode, extraHeight = 69) {
-    const scrollView = this.refs.keyboardScrollView.getScrollResponder();
-    setTimeout(() => {
-      scrollView.scrollResponderScrollNativeHandleToKeyboard(
-        reactNode,
-        extraHeight,
-        true
-      );
-    }, 220);
+    if (this.keyboardAwareScrollviewRef.current) {
+      const scrollView =
+        this.keyboardAwareScrollviewRef.current.getScrollResponder();
+      setTimeout(() => {
+        scrollView.scrollResponderScrollNativeHandleToKeyboard(
+          reactNode,
+          extraHeight,
+          true
+        );
+      }, 220);
+    }
   }
 
   render() {
     return (
       <ScrollView
         keyboardShouldPersistTaps={false}
-        ref="keyboardScrollView"
+        ref={this.keyboardAwareScrollviewRef}
         keyboardDismissMode="interactive"
         contentInset={{ bottom: this.state.keyboardSpace }}
         showsVerticalScrollIndicator={true}

--- a/src/fields/CountDownField.ios.js
+++ b/src/fields/CountDownField.ios.js
@@ -7,16 +7,20 @@ let { StyleSheet } = ReactNative;
 import { DatePickerComponent } from "../lib/DatePickerComponent";
 
 export class CountDownField extends React.Component {
+  constructor(props) {
+    super(props);
+    this.datePickerRef = createRef();
+  }
   setTime(date) {
-    this.refs.datePickerComponent.setDate(date);
+    if (this.datePickerRef.current) {
+      this.datePickerRef.current.setDate(date);
+    }
   }
   render() {
-    /*
-
- */
     return (
       <DatePickerComponent
         {...this.props}
+        ref={this.datePickerRef}
         mode="countdown"
         labelStyle={[formStyles.fieldText, this.props.labelStyle]}
         valueStyle={[formStyles.fieldValue, this.props.valueStyle]}

--- a/src/fields/DatePickerField.android.js
+++ b/src/fields/DatePickerField.android.js
@@ -6,18 +6,18 @@ import { DatePickerComponent } from "../lib/DatePickerComponent";
 export class DatePickerField extends React.Component {
   constructor(props) {
     super(props);
-    this.datePickerComponentRef = React.createRef();
+    this.datePickerRef = React.createRef();
   }
   setDate(date) {
-    if (this.datePickerComponentRef.current) {
-      this.datePickerComponentRef.current.setDate(date);
+    if (this.datePickerRef.current) {
+      this.datePickerRef.current.setDate(date);
     }
   }
 
   render() {
     return (
       <DatePickerComponent
-        ref={this.datePickerComponentRef}
+        ref={this.datePickerRef}
         {...this.props}
         labelStyle={this.props.labelStyle}
         valueStyle={this.props.valueStyle}

--- a/src/fields/DatePickerField.android.js
+++ b/src/fields/DatePickerField.android.js
@@ -4,14 +4,20 @@ import React from "react";
 import { DatePickerComponent } from "../lib/DatePickerComponent";
 
 export class DatePickerField extends React.Component {
+  constructor(props) {
+    super(props);
+    this.datePickerComponentRef = React.createRef();
+  }
   setDate(date) {
-    this.refs.datePickerComponent.setDate(date);
+    if (this.datePickerComponentRef.current) {
+      this.datePickerComponentRef.current.setDate(date);
+    }
   }
 
   render() {
     return (
       <DatePickerComponent
-        ref="datePickerComponent"
+        ref={this.datePickerComponentRef}
         {...this.props}
         labelStyle={this.props.labelStyle}
         valueStyle={this.props.valueStyle}

--- a/src/fields/DatePickerField.ios.js
+++ b/src/fields/DatePickerField.ios.js
@@ -6,11 +6,11 @@ import { DatePickerComponent } from "../lib/DatePickerComponent";
 export class DatePickerField extends React.Component {
   constructor(props) {
     super(props);
-    this.datePickerComponentRef = React.createRef();
+    this.datePickerRef = React.createRef();
   }
   setDate(date) {
-    if (this.datePickerComponentRef.current) {
-      this.datePickerComponentRef.current.setDate(date);
+    if (this.datePickerRef.current) {
+      this.datePickerRef.current.setDate(date);
     }
   }
 
@@ -18,7 +18,7 @@ export class DatePickerField extends React.Component {
     return (
       <DatePickerComponent
         {...this.props}
-        ref={this.datePickerComponentRef}
+        ref={this.datePickerRef}
         labelStyle={this.props.labelStyle}
         valueStyle={this.props.valueStyle}
         valueContainerStyle={this.props.valueContainerStyle}

--- a/src/fields/DatePickerField.ios.js
+++ b/src/fields/DatePickerField.ios.js
@@ -1,19 +1,24 @@
 "use strict";
 
 import React from "react";
-
 import { DatePickerComponent } from "../lib/DatePickerComponent";
 
 export class DatePickerField extends React.Component {
+  constructor(props) {
+    super(props);
+    this.datePickerComponentRef = React.createRef();
+  }
   setDate(date) {
-    this.refs.datePickerComponent.setDate(date);
+    if (this.datePickerComponentRef.current) {
+      this.datePickerComponentRef.current.setDate(date);
+    }
   }
 
   render() {
     return (
       <DatePickerComponent
         {...this.props}
-        ref="datePickerComponent"
+        ref={this.datePickerComponentRef}
         labelStyle={this.props.labelStyle}
         valueStyle={this.props.valueStyle}
         valueContainerStyle={this.props.valueContainerStyle}

--- a/src/fields/DatePickerField.windows.js
+++ b/src/fields/DatePickerField.windows.js
@@ -6,11 +6,11 @@ import { DatePickerComponent } from "../lib/DatePickerComponent";
 export class DatePickerField extends React.Component {
   constructor(props) {
     super(props);
-    this.datePickerComponentRef = React.createRef();
+    this.datePickerRef = React.createRef();
   }
   setDate(date) {
-    if (this.datePickerComponentRef.current) {
-      this.datePickerComponentRef.current.setDate(date);
+    if (this.datePickerRef.current) {
+      this.datePickerRef.current.setDate(date);
     }
   }
 
@@ -18,7 +18,7 @@ export class DatePickerField extends React.Component {
     return (
       <DatePickerComponent
         {...this.props}
-        ref={this.datePickerComponentRef}
+        ref={this.datePickerRef}
         labelStyle={this.props.labelStyle}
         valueStyle={this.props.valueStyle}
         valueContainerStyle={this.props.valueContainerStyle}

--- a/src/fields/DatePickerField.windows.js
+++ b/src/fields/DatePickerField.windows.js
@@ -1,20 +1,24 @@
 "use strict";
 
 import React from "react";
-import { View, StyleSheet, TextInput, Text } from "react-native";
-
 import { DatePickerComponent } from "../lib/DatePickerComponent";
 
 export class DatePickerField extends React.Component {
+  constructor(props) {
+    super(props);
+    this.datePickerComponentRef = React.createRef();
+  }
   setDate(date) {
-    this.refs.datePickerComponent.setDate(date);
+    if (this.datePickerComponentRef.current) {
+      this.datePickerComponentRef.current.setDate(date);
+    }
   }
 
   render() {
     return (
       <DatePickerComponent
         {...this.props}
-        ref="datePickerComponent"
+        ref={this.datePickerComponentRef}
         labelStyle={this.props.labelStyle}
         valueStyle={this.props.valueStyle}
         valueContainerStyle={this.props.valueContainerStyle}

--- a/src/fields/InputField.android.js
+++ b/src/fields/InputField.android.js
@@ -7,27 +7,27 @@ import { InputComponent } from "../lib/InputComponent";
 export class InputField extends React.Component {
   constructor(props) {
     super(props);
-    this.inputFieldRef = React.createRef();
+    this.fieldComponentRef = React.createRef();
   }
   handleValidation(isValid, validationErrors) {
     this.valid = isValid;
     this.validationErrors = validationErrors;
   }
   setValue(value) {
-    if (this.inputFieldRef.current) {
-      this.inputFieldRef.current.setValue(value);
+    if (this.fieldComponentRef.current) {
+      this.fieldComponentRef.current.setValue(value);
     }
   }
   focus() {
-    if (this.inputFieldRef.current) {
-      this.inputFieldRef.current.focus();
+    if (this.fieldComponentRef.current) {
+      this.fieldComponentRef.current.focus();
     }
   }
   render() {
     return (
       <InputComponent
         {...this.props}
-        ref={this.inputFieldRef}
+        ref={this.fieldComponentRef}
         onValidation={this.handleValidation.bind(this)}
       />
     );

--- a/src/fields/InputField.android.js
+++ b/src/fields/InputField.android.js
@@ -1,27 +1,33 @@
 "use strict";
 
 import React from "react";
-import ReactNative from "react-native";
 import { InputComponent } from "../lib/InputComponent";
 
-const { StyleSheet } = ReactNative;
 
 export class InputField extends React.Component {
+  constructor(props) {
+    super(props);
+    this.inputFieldRef = React.createRef();
+  }
   handleValidation(isValid, validationErrors) {
     this.valid = isValid;
     this.validationErrors = validationErrors;
   }
   setValue(value) {
-    this.refs.fieldComponent.setValue(value);
+    if (this.inputFieldRef.current) {
+      this.inputFieldRef.current.setValue(value);
+    }
   }
   focus() {
-    this.refs.fieldComponent.focus();
+    if (this.inputFieldRef.current) {
+      this.inputFieldRef.current.focus();
+    }
   }
   render() {
     return (
       <InputComponent
         {...this.props}
-        ref="fieldComponent"
+        ref={this.inputFieldRef}
         onValidation={this.handleValidation.bind(this)}
       />
     );

--- a/src/fields/InputField.ios.js
+++ b/src/fields/InputField.ios.js
@@ -8,7 +8,7 @@ import { InputComponent } from "../lib/InputComponent";
 export class InputField extends React.Component {
   constructor(props) {
     super(props);
-    this.inputFieldRef = React.createRef();
+    this.fieldComponentRef = React.createRef();
   }
 
   handleValidation(isValid, validationErrors) {
@@ -16,20 +16,20 @@ export class InputField extends React.Component {
     this.validationErrors = validationErrors;
   }
   setValue(value) {
-    if (this.inputFieldRef.current) {
-      this.inputFieldRef.current.setValue(value);
+    if (this.fieldComponentRef.current) {
+      this.fieldComponentRef.current.setValue(value);
     }
   }
   focus() {
-    if (this.inputFieldRef.current) {
-      this.inputFieldRef.current.focus();
+    if (this.fieldComponentRef.current) {
+      this.fieldComponentRef.current.focus();
     }
   }
   render() {
     return (
       <InputComponent
         {...this.props}
-        ref={this.inputFieldRef}
+        ref={this.fieldComponentRef}
         onValidation={this.handleValidation.bind(this)}
         labelStyle={this.props.labelStyle}
         inputStyle={this.props.style}

--- a/src/fields/InputField.ios.js
+++ b/src/fields/InputField.ios.js
@@ -2,27 +2,34 @@
 
 import React from "react";
 import PropTypes from "prop-types";
-import ReactNative from "react-native";
 import { InputComponent } from "../lib/InputComponent";
 
-const { StyleSheet } = ReactNative;
 
 export class InputField extends React.Component {
+  constructor(props) {
+    super(props);
+    this.inputFieldRef = React.createRef();
+  }
+
   handleValidation(isValid, validationErrors) {
     this.valid = isValid;
     this.validationErrors = validationErrors;
   }
   setValue(value) {
-    this.refs.fieldComponent.setValue(value);
+    if (this.inputFieldRef.current) {
+      this.inputFieldRef.current.setValue(value);
+    }
   }
   focus() {
-    this.refs.fieldComponent.focus();
+    if (this.inputFieldRef.current) {
+      this.inputFieldRef.current.focus();
+    }
   }
   render() {
     return (
       <InputComponent
         {...this.props}
-        ref="fieldComponent"
+        ref={this.inputFieldRef}
         onValidation={this.handleValidation.bind(this)}
         labelStyle={this.props.labelStyle}
         inputStyle={this.props.style}

--- a/src/fields/InputField.windows.js
+++ b/src/fields/InputField.windows.js
@@ -1,28 +1,33 @@
 "use strict";
 
 import React from "react";
-import ReactNative from "react-native";
 import PropTypes from "prop-types";
 import { InputComponent } from "../lib/InputComponent";
 
-const { StyleSheet } = ReactNative;
-
 export class InputField extends React.Component {
+  constructor(props) {
+    super(props);
+    this.fieldComponentRef = React.createRef();
+  }
   handleValidation(isValid, validationErrors) {
     this.valid = isValid;
     this.validationErrors = validationErrors;
   }
   setValue(value) {
-    this.refs.fieldComponent.setValue(value);
+    if (this.fieldComponentRef.current) {
+      this.fieldComponentRef.current(value);
+    }
   }
   focus() {
-    this.refs.fieldComponent.focus();
+    if (this.fieldComponentRef.current) {
+      this.fieldComponentRef.current.focus();
+    }
   }
   render() {
     return (
       <InputComponent
         {...this.props}
-        ref="fieldComponent"
+        ref={this.fieldComponentRef}
         onValidation={this.handleValidation.bind(this)}
         labelStyle={this.props.labelStyle}
         inputStyle={this.props.style}

--- a/src/fields/PickerField.android.js
+++ b/src/fields/PickerField.android.js
@@ -7,18 +7,18 @@ import { PickerComponent } from "../lib/PickerComponent";
 export class PickerField extends React.Component {
   constructor(props) {
     super(props);
-    this.pickerFieldRef = React.createRef();
+    this.fieldComponentRef = React.createRef();
   }
   setValue(value) {
-    if (this.pickerFieldRef.current) {
-      this.pickerFieldRef.current.setValue(value);
+    if (this.fieldComponentRef.current) {
+      this.fieldComponentRef.current.setValue(value);
     }
   }
   render() {
     return (
       <PickerComponent
         {...this.props}
-        ref={this.pickerFieldRef}
+        ref={this.fieldComponentRef}
         pickerProps={{
           style: this.props.containerStyle
         }}

--- a/src/fields/PickerField.android.js
+++ b/src/fields/PickerField.android.js
@@ -1,20 +1,24 @@
 "use strict";
 
 import React from "react";
-import ReactNative from "react-native";
-let { StyleSheet } = ReactNative;
 
 import { PickerComponent } from "../lib/PickerComponent";
 
 export class PickerField extends React.Component {
+  constructor(props) {
+    super(props);
+    this.pickerFieldRef = React.createRef();
+  }
   setValue(value) {
-    this.refs.fieldComponent.setValue(value);
+    if (this.pickerFieldRef.current) {
+      this.pickerFieldRef.current.setValue(value);
+    }
   }
   render() {
     return (
       <PickerComponent
         {...this.props}
-        ref="fieldComponent"
+        ref={this.pickerFieldRef}
         pickerProps={{
           style: this.props.containerStyle
         }}

--- a/src/fields/PickerField.ios.js
+++ b/src/fields/PickerField.ios.js
@@ -1,20 +1,24 @@
 "use strict";
 
 import React from "react";
-import ReactNative from "react-native";
-let { StyleSheet } = ReactNative;
 
 import { PickerComponent } from "../lib/PickerComponent";
 
 export class PickerField extends React.Component {
+  constructor(props) {
+    super(props);
+    this.pickerFieldRef = React.createRef();
+  }
   setValue(value) {
-    this.refs.fieldComponent.setValue(value);
+    if (this.pickerFieldRef.current) {
+      this.pickerFieldRef.current.setValue(value);
+    }
   }
   render() {
     return (
       <PickerComponent
         {...this.props}
-        ref="fieldComponent"
+        ref={this.pickerFieldRef}
         labelStyle={this.props.labelStyle}
         valueStyle={this.props.valueStyle}
         valueContainerStyle={this.props.valueContainerStyle}

--- a/src/fields/PickerField.ios.js
+++ b/src/fields/PickerField.ios.js
@@ -7,18 +7,18 @@ import { PickerComponent } from "../lib/PickerComponent";
 export class PickerField extends React.Component {
   constructor(props) {
     super(props);
-    this.pickerFieldRef = React.createRef();
+    this.fieldComponentRef = React.createRef();
   }
   setValue(value) {
-    if (this.pickerFieldRef.current) {
-      this.pickerFieldRef.current.setValue(value);
+    if (this.fieldComponentRef.current) {
+      this.fieldComponentRef.current.setValue(value);
     }
   }
   render() {
     return (
       <PickerComponent
         {...this.props}
-        ref={this.pickerFieldRef}
+        ref={this.fieldComponentRef}
         labelStyle={this.props.labelStyle}
         valueStyle={this.props.valueStyle}
         valueContainerStyle={this.props.valueContainerStyle}

--- a/src/fields/PickerField.windows.js
+++ b/src/fields/PickerField.windows.js
@@ -1,20 +1,24 @@
 "use strict";
 
 import React from "react";
-import ReactNative from "react-native";
-let { View, StyleSheet, TextInput, Text } = ReactNative;
 
 import { PickerComponent } from "../lib/PickerComponent";
 
 export class PickerField extends React.Component {
+  constructor(props) {
+    super(props);
+    this.pickerFieldRef = React.createRef();
+  }
   setValue(value) {
-    this.refs.fieldComponent.setValue(value);
+    if (this.pickerFieldRef.current) {
+      this.pickerFieldRef.current.setValue(value);
+    }
   }
   render() {
     return (
       <PickerComponent
         {...this.props}
-        ref="fieldComponent"
+        ref={this.pickerFieldRef}
         labelStyle={this.props.labelStyle}
         valueStyle={this.props.valueStyle}
         valueContainerStyle={this.props.valueContainerStyle}

--- a/src/fields/PickerField.windows.js
+++ b/src/fields/PickerField.windows.js
@@ -7,18 +7,18 @@ import { PickerComponent } from "../lib/PickerComponent";
 export class PickerField extends React.Component {
   constructor(props) {
     super(props);
-    this.pickerFieldRef = React.createRef();
+    this.fieldComponentRef = React.createRef();
   }
   setValue(value) {
-    if (this.pickerFieldRef.current) {
-      this.pickerFieldRef.current.setValue(value);
+    if (this.fieldComponentRef.current) {
+      this.fieldComponentRef.current.setValue(value);
     }
   }
   render() {
     return (
       <PickerComponent
         {...this.props}
-        ref={this.pickerFieldRef}
+        ref={this.fieldComponentRef}
         labelStyle={this.props.labelStyle}
         valueStyle={this.props.valueStyle}
         valueContainerStyle={this.props.valueContainerStyle}

--- a/src/fields/SwitchField.android.js
+++ b/src/fields/SwitchField.android.js
@@ -5,14 +5,20 @@ import React from "react";
 import { SwitchComponent } from "../lib/SwitchComponent";
 
 export class SwitchField extends React.Component {
+  constructor(props) {
+    super(props);
+    this.switchFieldRef = React.createRef();
+  }
   setValue(value) {
-    this.refs.fieldComponent.setValue(value);
+    if (this.switchFieldRef.current) {
+      this.switchFieldRef.current.setValue(value);
+    }
   }
   render() {
     return (
       <SwitchComponent
         {...this.props}
-        ref="fieldComponent"
+        ref={this.switchFieldRef}
         containerStyle={this.props.containerStyle}
         labelStyle={this.props.labelStyle}
         switchStyle={this.props.switchStyle}

--- a/src/fields/SwitchField.android.js
+++ b/src/fields/SwitchField.android.js
@@ -7,18 +7,18 @@ import { SwitchComponent } from "../lib/SwitchComponent";
 export class SwitchField extends React.Component {
   constructor(props) {
     super(props);
-    this.switchFieldRef = React.createRef();
+    this.fieldComponentRef = React.createRef();
   }
   setValue(value) {
-    if (this.switchFieldRef.current) {
-      this.switchFieldRef.current.setValue(value);
+    if (this.fieldComponentRef.current) {
+      this.fieldComponentRef.current.setValue(value);
     }
   }
   render() {
     return (
       <SwitchComponent
         {...this.props}
-        ref={this.switchFieldRef}
+        ref={this.fieldComponentRef}
         containerStyle={this.props.containerStyle}
         labelStyle={this.props.labelStyle}
         switchStyle={this.props.switchStyle}

--- a/src/fields/SwitchField.ios.js
+++ b/src/fields/SwitchField.ios.js
@@ -5,14 +5,20 @@ import React from "react";
 import { SwitchComponent } from "../lib/SwitchComponent";
 
 export class SwitchField extends React.Component {
+  constructor(props) {
+    super(props);
+    this.switchFieldRef = React.createRef();
+  }
   setValue(value) {
-    this.refs.fieldComponent.setValue(value);
+    if (this.switchFieldRef.current) {
+      this.switchFieldRef.current.setValue(value);
+    }
   }
   render() {
     return (
       <SwitchComponent
         {...this.props}
-        ref="fieldComponent"
+        ref={this.switchFieldRef}
         containerStyle={this.props.containerStyle}
         labelStyle={this.props.labelStyle}
         switchStyle={this.props.switchStyle}

--- a/src/fields/SwitchField.ios.js
+++ b/src/fields/SwitchField.ios.js
@@ -7,18 +7,18 @@ import { SwitchComponent } from "../lib/SwitchComponent";
 export class SwitchField extends React.Component {
   constructor(props) {
     super(props);
-    this.switchFieldRef = React.createRef();
+    this.fieldComponentRef = React.createRef();
   }
   setValue(value) {
-    if (this.switchFieldRef.current) {
-      this.switchFieldRef.current.setValue(value);
+    if (this.fieldComponentRef.current) {
+      this.fieldComponentRef.current.setValue(value);
     }
   }
   render() {
     return (
       <SwitchComponent
         {...this.props}
-        ref={this.switchFieldRef}
+        ref={this.fieldComponentRef}
         containerStyle={this.props.containerStyle}
         labelStyle={this.props.labelStyle}
         switchStyle={this.props.switchStyle}

--- a/src/fields/SwitchField.windows.js
+++ b/src/fields/SwitchField.windows.js
@@ -5,14 +5,20 @@ import React from "react";
 import { SwitchComponent } from "../lib/SwitchComponent";
 
 export class SwitchField extends React.Component {
+  constructor(props) {
+    super(props);
+    this.switchFieldRef = React.createRef();
+  }
   setValue(value) {
-    this.refs.fieldComponent.setValue(value);
+    if (this.switchFieldRef.current) {
+      this.switchFieldRef.current.setValue(value);
+    }
   }
   render() {
     return (
       <SwitchComponent
         {...this.props}
-        ref="fieldComponent"
+        ref={this.switchFieldRef}
         containerStyle={this.props.containerStyle}
         labelStyle={this.props.labelStyle}
         switchStyle={this.props.switchStyle}

--- a/src/fields/SwitchField.windows.js
+++ b/src/fields/SwitchField.windows.js
@@ -7,18 +7,18 @@ import { SwitchComponent } from "../lib/SwitchComponent";
 export class SwitchField extends React.Component {
   constructor(props) {
     super(props);
-    this.switchFieldRef = React.createRef();
+    this.fieldComponentRef = React.createRef();
   }
   setValue(value) {
-    if (this.switchFieldRef.current) {
-      this.switchFieldRef.current.setValue(value);
+    if (this.fieldComponentRef.current) {
+      this.fieldComponentRef.current.setValue(value);
     }
   }
   render() {
     return (
       <SwitchComponent
         {...this.props}
-        ref={this.switchFieldRef}
+        ref={this.fieldComponentRef}
         containerStyle={this.props.containerStyle}
         labelStyle={this.props.labelStyle}
         switchStyle={this.props.switchStyle}

--- a/src/fields/TimePickerField.android.js
+++ b/src/fields/TimePickerField.android.js
@@ -7,11 +7,11 @@ import { TimePickerComponent } from "../lib/TimePickerComponent";
 export class TimePickerField extends React.Component {
   constructor(props) {
     super(props);
-    this.timePickerFieldRef = React.createRef();
+    this.datePickerRef = React.createRef();
   }
   setTime(date) {
-    if (this.timePickerFieldRef.current) {
-      this.timePickerFieldRef.current.setTime(date);
+    if (this.datePickerRef.current) {
+      this.datePickerRef.current.setTime(date);
     }
   }
 
@@ -19,7 +19,7 @@ export class TimePickerField extends React.Component {
     return (
       <TimePickerComponent
         {...this.props}
-        ref={this.timePickerFieldRef}
+        ref={this.datePickerRef}
         labelStyle={this.props.labelStyle}
         valueStyle={this.props.valueStyle}
         valueContainerStyle={this.props.valueContainerStyle}

--- a/src/fields/TimePickerField.android.js
+++ b/src/fields/TimePickerField.android.js
@@ -1,21 +1,25 @@
 "use strict";
 
 import React from "react";
-import ReactNative from "react-native";
-let { View, StyleSheet, TextInput, Text } = ReactNative;
 
 import { TimePickerComponent } from "../lib/TimePickerComponent";
 
 export class TimePickerField extends React.Component {
+  constructor(props) {
+    super(props);
+    this.timePickerFieldRef = React.createRef();
+  }
   setTime(date) {
-    this.refs.datePickerComponent.setTime(date);
+    if (this.timePickerFieldRef.current) {
+      this.timePickerFieldRef.current.setTime(date);
+    }
   }
 
   render() {
     return (
       <TimePickerComponent
         {...this.props}
-        ref="fieldComponent"
+        ref={this.timePickerFieldRef}
         labelStyle={this.props.labelStyle}
         valueStyle={this.props.valueStyle}
         valueContainerStyle={this.props.valueContainerStyle}

--- a/src/fields/TimePickerField.ios.js
+++ b/src/fields/TimePickerField.ios.js
@@ -9,18 +9,18 @@ import { DatePickerComponent } from "../lib/DatePickerComponent";
 export class TimePickerField extends React.Component {
   constructor(props) {
     super(props);
-    this.timePickerFieldRef = React.createRef();
+    this.datePickerRef = React.createRef();
   }
   setTime(date) {
-    if (this.timePickerFieldRef.current) {
-      this.timePickerFieldRef.current.setTime(date);
+    if (this.datePickerRef.current) {
+      this.datePickerRef.current.setDate(date);
     }
   }
   render() {
     return (
       <DatePickerComponent
         {...this.props}
-        ref={this.timePickerFieldRef}
+        ref={this.datePickerRef}
         mode="time"
         labelStyle={this.props.labelStyle}
         valueStyle={this.props.valueStyle}

--- a/src/fields/TimePickerField.ios.js
+++ b/src/fields/TimePickerField.ios.js
@@ -7,13 +7,20 @@ let { StyleSheet } = ReactNative;
 import { DatePickerComponent } from "../lib/DatePickerComponent";
 
 export class TimePickerField extends React.Component {
+  constructor(props) {
+    super(props);
+    this.timePickerFieldRef = React.createRef();
+  }
   setTime(date) {
-    this.refs.datePickerComponent.setDate(date);
+    if (this.timePickerFieldRef.current) {
+      this.timePickerFieldRef.current.setTime(date);
+    }
   }
   render() {
     return (
       <DatePickerComponent
         {...this.props}
+        ref={this.timePickerFieldRef}
         mode="time"
         labelStyle={this.props.labelStyle}
         valueStyle={this.props.valueStyle}

--- a/src/fields/TimePickerField.windows.js
+++ b/src/fields/TimePickerField.windows.js
@@ -8,18 +8,18 @@ import { DatePickerComponent } from "../lib/DatePickerComponent";
 export class TimePickerField extends React.Component {
   constructor(props) {
     super(props);
-    this.timePickerFieldRef = React.createRef();
+    this.datePickerRef = React.createRef();
   }
   setTime(date) {
-    if (this.timePickerFieldRef.current) {
-      this.timePickerFieldRef.current.setDate(date);
+    if (this.datePickerRef.current) {
+      this.datePickerRef.current.setDate(date);
     }
   }
   render() {
     return (
       <DatePickerComponent
         {...this.props}
-        ref={this.timePickerFieldRef}
+        ref={this.datePickerRef}
         mode="time"
         labelStyle={this.props.labelStyle}
         valueStyle={this.props.valueStyle}

--- a/src/fields/TimePickerField.windows.js
+++ b/src/fields/TimePickerField.windows.js
@@ -2,18 +2,24 @@
 
 import React from "react";
 import ReactNative from "react-native";
-let { View, StyleSheet, TextInput, Text } = ReactNative;
 
 import { DatePickerComponent } from "../lib/DatePickerComponent";
 
 export class TimePickerField extends React.Component {
+  constructor(props) {
+    super(props);
+    this.timePickerFieldRef = React.createRef();
+  }
   setTime(date) {
-    this.refs.datePickerComponent.setDate(date);
+    if (this.timePickerFieldRef.current) {
+      this.timePickerFieldRef.current.setDate(date);
+    }
   }
   render() {
     return (
       <DatePickerComponent
         {...this.props}
+        ref={this.timePickerFieldRef}
         mode="time"
         labelStyle={this.props.labelStyle}
         valueStyle={this.props.valueStyle}

--- a/src/lib/DatePickerComponent.android.js
+++ b/src/lib/DatePickerComponent.android.js
@@ -26,6 +26,7 @@ export class DatePickerComponent extends React.Component {
     };
 
     this._togglePicker = this._togglePicker.bind(this);
+    this.inputBoxRef = React.createRef();
     this.handleClear = this.handleClear.bind(this);
     this.handleDateValueChange = this.handleDateValueChange.bind(this);
     this.handleLayoutChange = this.handleLayoutChange.bind(this);
@@ -176,7 +177,7 @@ export class DatePickerComponent extends React.Component {
     const onPress = active ? this._togglePicker : null;
     return (
       <View>
-        <Field {...this.props} ref="inputBox" onPress={onPress}>
+        <Field {...this.props} ref={this.inputBoxRef} onPress={onPress}>
           <View
             style={this.props.containerStyle}
             onLayout={this.handleLayoutChange}

--- a/src/lib/DatePickerComponent.ios.js
+++ b/src/lib/DatePickerComponent.ios.js
@@ -26,6 +26,7 @@ export class DatePickerComponent extends React.Component {
 
     this._renderContent = this._renderContent.bind(this);
     this._togglePicker = this._togglePicker.bind(this);
+    this.inputBoxRef = React.createRef();
     this.handleClear = this.handleClear.bind(this);
     this.handleLayoutChange = this.handleLayoutChange.bind(this);
     this.handleValueChange = this.handleValueChange.bind(this);
@@ -166,7 +167,7 @@ export class DatePickerComponent extends React.Component {
     const onPress = active ? this._togglePicker : null;
     return (
       <View>
-        <Field {...this.props} ref="inputBox" onPress={onPress}>
+        <Field {...this.props} ref={this.inputBoxRef} onPress={onPress}>
           <View
             style={[this.props.containerStyle]}
             onLayout={this.handleLayoutChange}

--- a/src/lib/DatePickerComponent.windows.js
+++ b/src/lib/DatePickerComponent.windows.js
@@ -27,6 +27,7 @@ export class DatePickerComponent extends React.Component {
     };
 
     this._togglePicker = this._togglePicker.bind(this);
+    this.inputBoxRef = React.createRef();
     this.handleClear = this.handleClear.bind(this);
     this.handleDateValueChange = this.handleDateValueChange.bind(this);
     this.handleLayoutChange = this.handleLayoutChange.bind(this);
@@ -195,7 +196,7 @@ export class DatePickerComponent extends React.Component {
     const onPress = active ? this._togglePicker : null;
     return (
       <View>
-        <Field {...this.props} ref="inputBox" onPress={onPress}>
+        <Field {...this.props} ref={this.inputBoxRef} onPress={onPress}>
           <View
             style={this.props.containerStyle}
             onLayout={this.handleLayoutChange}

--- a/src/lib/PickerComponent.android.js
+++ b/src/lib/PickerComponent.android.js
@@ -13,6 +13,7 @@ export class PickerComponent extends React.Component {
     super(props);
     this.state = {};
     this.pickerMeasures = {};
+    this.inputBoxRef = React.createRef();
   }
 
   setValue(value) {}
@@ -56,7 +57,7 @@ export class PickerComponent extends React.Component {
 
     return (
       <View>
-        <Field {...this.props} ref="inputBox" onPress={this.props.onPress}>
+        <Field {...this.props} ref={this.inputBoxRef} onPress={this.props.onPress}>
           <View
             style={this.props.containerStyle}
             onLayout={this.handleLayoutChange}

--- a/src/lib/PickerComponent.ios.js
+++ b/src/lib/PickerComponent.ios.js
@@ -11,10 +11,10 @@ import { sanatisePicklistValues } from "./helpers";
 class RenderedSelector extends React.Component {
   constructor(props) {
     super(props);
-
     this.state = {
       value: props.value
     };
+    this.inputBoxRef = React.createRef();
   }
 
   handleValueChange(value) {
@@ -91,9 +91,11 @@ export class PickerComponent extends React.Component {
 
   _scrollToInput(event) {
     if (this.props.onFocus) {
-      let handle = ReactNative.findNodeHandle(this.refs.inputBox);
+      if (this.inputBoxRef) {
+        let handle = ReactNative.findNodeHandle(this.inputBoxRef.current);
 
-      this.props.onFocus(event, handle);
+        this.props.onFocus(event, handle);
+      }
     }
   }
 
@@ -150,7 +152,7 @@ export class PickerComponent extends React.Component {
       <View>
         <Field
           {...this.props}
-          ref="inputBox"
+          ref={this.inputBoxRef}
           onPress={this._togglePicker.bind(this)}
         >
           <View

--- a/src/lib/PickerComponent.windows.js
+++ b/src/lib/PickerComponent.windows.js
@@ -15,6 +15,7 @@ export class PickerComponent extends React.Component {
       value: props.value,
       isPickerVisible: false
     };
+    this.inputBoxRef = React.createRef();
     this.pickerMeasures = {};
   }
 
@@ -56,9 +57,11 @@ export class PickerComponent extends React.Component {
 
   _scrollToInput = event => {
     if (this.props.onFocus) {
-      const handle = findNodeHandle(this.refs.inputBox);
+      if (this.inputBoxRef) {
+        let handle = ReactNative.findNodeHandle(this.inputBoxRef.current);
 
-      this.props.onFocus(event, handle);
+        this.props.onFocus(event, handle);
+      }
     }
   };
 
@@ -85,7 +88,7 @@ export class PickerComponent extends React.Component {
 
     return (
       <View>
-        <Field {...this.props} ref="inputBox" onPress={this.props.onPress}>
+        <Field {...this.props} ref={this.inputBoxRef} onPress={this.props.onPress}>
           <View
             style={this.props.containerStyle}
             onLayout={this.handleLayoutChange}

--- a/src/lib/TimePickerComponent.android.js
+++ b/src/lib/TimePickerComponent.android.js
@@ -16,6 +16,7 @@ export class TimePickerComponent extends React.Component {
     this.state = {
       isTimePickerVisible: false
     };
+    this.inputBoxRef = React.createRef();
   }
 
   componentDidMount() {
@@ -76,7 +77,7 @@ export class TimePickerComponent extends React.Component {
       <View>
         <Field
           {...this.props}
-          ref="inputBox"
+          ref={this.inputBoxRef}
           onPress={this._togglePicker}
         >
           <View


### PR DESCRIPTION
What: Remove legacy string refs and references to this.refs. Instead rely on the fieldKey provided instead of the string ref to identify which component toupdate (in AxsyForm, which is the main (only?) place this lib is used, the fieldKey was always set to the same value as the string ref anyway. Also update docs to remove references that would lead people to believe that we should use string refs

Why: needed for RN uplift