### PR TITLE
use inline picker for datetime picker iOS

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "test:watch": "jest --watchAll",
     "format": "prettier --write --loglevel=silent"
   },
-  "version": "0.10.0",
+  "version": "0.10.1",
   "devDependencies": {
     "@tsconfig/react-native": "^1.0.4",
     "@types/react": "^17.0.39",

--- a/src/lib/DatePickerComponent.ios.js
+++ b/src/lib/DatePickerComponent.ios.js
@@ -107,7 +107,7 @@ export class DatePickerComponent extends React.Component {
   _renderContent() {
     let datePicker = (
       <DateTimePicker
-        display={"spinner"}
+        display={"inline"}
         maximumDate={this.props.maximumDate}
         minimumDate={this.props.minimumDate}
         minuteInterval={this.props.minuteInterval}


### PR DESCRIPTION
What: Set "mode" prop to "inline" for iOS
Why: Part of https://github.com/axsy-dev/react-app/issues/11127